### PR TITLE
wffweb-12.0.0-beta.5 released changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://img.shields.io/badge/build-passing-greensvg?style=flat)](https://app.circleci.com/pipelines/github/webfirmframework/wff?branch=master&filter=all)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/410601e16dc54b0a973c03845ad790c2)](https://www.codacy.com/app/webfirm-framework/wff?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=webfirmframework/wff&amp;utm_campaign=Badge_Grade)
 [![Stackoverflow](https://img.shields.io/badge/stackoverflow-wffweb-orange.svg)](https://stackoverflow.com/questions/tagged/wffweb)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.webfirmframework/wffweb/badge.svg)](https://search.maven.org/#artifactdetails%7Ccom.webfirmframework%7Cwffweb%7C12.0.0-beta.3%7Cjar)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.webfirmframework/wffweb/badge.svg)](https://search.maven.org/#artifactdetails%7Ccom.webfirmframework%7Cwffweb%7C12.0.0-beta.5%7Cjar)
 [![javadoc](https://img.shields.io/:wffweb-javadoc-blue.svg)](https://webfirmframework.github.io/wffweb/wffweb-javadoc)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![twitter](https://img.shields.io/badge/twitter-@wffweb-blue.svg)](https://webfirmframework.com/twitter)

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -76,7 +76,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.9.0</version>
+						<version>3.10.1</version>
 					</plugin>
 
 					<plugin>
@@ -102,7 +102,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
-						<version>3.3.2</version>
+						<version>3.4.0</version>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2.2</version>
+			<version>2.13.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.0.0-SNAPSHOT</version>
+	<version>12.0.0-beta.5</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -147,13 +147,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.1</version>
+			<version>2.13.2.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>de.undercouch</groupId>
 			<artifactId>bson4jackson</artifactId>
-			<version>2.13.0</version>
+			<version>2.13.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.0.0-beta.5</version>
+	<version>12.0.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/common/URIEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/common/URIEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2014-2022 Web Firm Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webfirmframework.wffweb.common;
+
+import com.webfirmframework.wffweb.common.URIEventInitiator;
+
+/**
+ * @since 12.0.0-beta.5
+ */
+public record URIEvent(String uriBefore, String uriAfter, URIEventInitiator initiator, boolean replace) {
+}

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/common/URIEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/common/URIEvent.java
@@ -15,8 +15,6 @@
  */
 package com.webfirmframework.wffweb.common;
 
-import com.webfirmframework.wffweb.common.URIEventInitiator;
-
 /**
  * @since 12.0.0-beta.5
  */

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/common/URIEventMask.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/common/URIEventMask.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2014-2022 Web Firm Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webfirmframework.wffweb.common;
+
+/**
+ * @since 12.0.0-beta.5
+ */
+public record URIEventMask(String uriBefore) {
+}

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/css/file/ExcludeCssBlock.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/css/file/ExcludeCssBlock.java
@@ -14,9 +14,6 @@
  * limitations under the License.
  * @author WFF
  */
-/**
- *
- */
 package com.webfirmframework.wffweb.css.file;
 
 import java.lang.annotation.ElementType;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFile.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFile.java
@@ -177,6 +177,7 @@ public enum WffJsFile {
             functionNameList.add("invokeAsyncWithPreFilterFunPD");
             functionNameList.add("extractValuesFromValueBytes");
             functionNameList.add("getDoubleFromOptimizedBytes");
+            functionNameList.add("setServerURIWithCallbackPvt");
             functionNameList.add("parseWffBinaryMessageBytes");
             functionNameList.add("invokeAsyncWithFilterFunPD");
             functionNameList.add("getAttrUpdatedWffBMBytes");
@@ -325,6 +326,7 @@ public enum WffJsFile {
             variableNameList.add("tgNamNdx");
             variableNameList.add("allTags");
             variableNameList.add("allTags");
+            variableNameList.add("rplcByt");
             variableNameList.add("wffIds");
             variableNameList.add("wffId");
             variableNameList.add("intId");

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/internal/tag/html/listener/URIChangeTagSupplier.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/internal/tag/html/listener/URIChangeTagSupplier.java
@@ -17,11 +17,12 @@ package com.webfirmframework.wffweb.internal.tag.html.listener;
 
 import java.io.Serializable;
 
+import com.webfirmframework.wffweb.common.URIEvent;
 import com.webfirmframework.wffweb.tag.html.AbstractHtml;
 
 @FunctionalInterface
 public interface URIChangeTagSupplier extends Serializable {
 
-    public abstract String supply(final AbstractHtml tag);
+    public abstract URIEvent supply(final AbstractHtml tag);
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
@@ -364,7 +364,10 @@ public final class JsUtil {
      * @return the returned string will be striped and all lines will be replaced by
      *         {@code \n} .
      * @since 3.0.15
+     * @deprecated use {@link JsUtil#toDynamicJsString(String)} instead of this
+     *             method. It does the same job.
      */
+    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
     public static String toDynamicJs(final String s) {
 
         final int[] codePoints = strip(s.codePoints().toArray());
@@ -402,7 +405,8 @@ public final class JsUtil {
 
     /**
      * It replaces all new lines by {@code \n} so that it can be used as a dynamic
-     * JavaScript string in event attributes js function body. It is unicode aware.
+     * JavaScript string variable value in js function body of event attributes. It
+     * is unicode aware.
      *
      * @param s
      * @return the string having all lines replaced by {@code \n} .

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
@@ -361,7 +361,7 @@ public final class JsUtil {
      * This method is mainly for internal use.
      *
      * @param s
-     * @return the returned string will be striped and all lines will be replace by
+     * @return the returned string will be striped and all lines will be replaced by
      *         {@code \n} .
      * @since 3.0.15
      */

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -33,6 +33,7 @@ import java.util.Deque;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
@@ -57,6 +58,7 @@ import com.webfirmframework.wffweb.PushFailedException;
 import com.webfirmframework.wffweb.WffRuntimeException;
 import com.webfirmframework.wffweb.common.URIEvent;
 import com.webfirmframework.wffweb.common.URIEventInitiator;
+import com.webfirmframework.wffweb.common.URIEventMask;
 import com.webfirmframework.wffweb.internal.security.object.BrowserPageSecurity;
 import com.webfirmframework.wffweb.internal.security.object.SecurityObject;
 import com.webfirmframework.wffweb.internal.server.page.js.WffJsFile;
@@ -2854,8 +2856,11 @@ public abstract class BrowserPage implements Serializable {
         final String lastURI = uriEvent != null ? uriEvent.uriAfter() : null;
         if (lastURI == null || !lastURI.equals(uri)) {
             if (uri != null) {
-                final URIEvent event = new URIEvent(lastURI, uri, initiator, replace);
-                beforeURIChange(event);
+                URIEvent event = new URIEvent(lastURI, uri, initiator, replace);
+                final URIEventMask uriEventMask = beforeURIChange(event);
+                event = uriEventMask != null && !Objects.equals(uriEventMask.uriBefore(), lastURI)
+                        ? new URIEvent(uriEventMask.uriBefore(), uri, initiator, replace)
+                        : event;
                 if (rootTag != null) {
                     changeInnerHtmlsOnTagsForURIChange(updateClientURI, event);
                 } else {
@@ -2919,8 +2924,9 @@ public abstract class BrowserPage implements Serializable {
      * @param uriEvent
      * @since 12.0.0-beta.5
      */
-    protected void beforeURIChange(final URIEvent uriEvent) {
+    protected URIEventMask beforeURIChange(final URIEvent uriEvent) {
         beforeURIChange(uriEvent.uriBefore(), uriEvent.uriAfter(), uriEvent.initiator());
+        return null;
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -2893,7 +2893,7 @@ public abstract class BrowserPage implements Serializable {
      * @deprecated override and use {@link BrowserPage#beforeURIChange(URIEvent)}
      *             instead of this method.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
     protected void beforeURIChange(final String uriBefore, final String uriAfter, final URIEventInitiator initiator) {
 
     }
@@ -2908,7 +2908,7 @@ public abstract class BrowserPage implements Serializable {
      * @deprecated override and use {@link BrowserPage#afterURIChange(URIEvent)}
      *             instead of this method.
      */
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
     protected void afterURIChange(final String uriBefore, final String uriAfter, final URIEventInitiator initiator) {
 
     }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -813,7 +813,7 @@ public abstract class BrowserPage implements Serializable {
                     final ServerMethod serverMethod = eventAttr.getServerMethod();
 
                     final ServerMethod.Event event = new ServerMethod.Event(wffBMObject, methodTag, attributeByName,
-                            null, eventAttr.getServerSideData(), uriEvent.uriAfter());
+                            null, eventAttr.getServerSideData(), uriEvent != null ? uriEvent.uriAfter() : null);
 
                     final WffBMObject returnedObject;
 
@@ -929,7 +929,7 @@ public abstract class BrowserPage implements Serializable {
                     // java memory
                     // model
                     returnedObject = serverMethod.serverMethod().invoke(new ServerMethod.Event(wffBMObject, null, null,
-                            methodName, serverMethod.serverSideData(), uriEvent.uriAfter()));
+                            methodName, serverMethod.serverSideData(), uriEvent != null ? uriEvent.uriAfter() : null));
                 }
 
             } catch (final Exception e) {
@@ -2781,7 +2781,7 @@ public abstract class BrowserPage implements Serializable {
      * @since 12.0.0-beta.1
      * @since 12.0.0-beta.5 replace param added
      */
-    private void changeInnerHtmlsOnTagsForURIChange(final boolean updateClientURI,  final URIEvent uriEvent) {
+    private void changeInnerHtmlsOnTagsForURIChange(final boolean updateClientURI, final URIEvent uriEvent) {
 
         final boolean setURIAndAfterSetURI[] = { false, false };
         try {
@@ -2849,7 +2849,6 @@ public abstract class BrowserPage implements Serializable {
      */
     private void setURI(final boolean updateClientURI, final String uri, final URIEventInitiator initiator,
             final boolean replace) {
-
 
         final URIEvent uriEvent = this.uriEvent;
         final String lastURI = uriEvent != null ? uriEvent.uriAfter() : null;
@@ -2943,7 +2942,7 @@ public abstract class BrowserPage implements Serializable {
      * @since 12.0.0-beta.1
      */
     public final String getURI() {
-        return uriEvent.uriAfter();
+        return uriEvent != null ? uriEvent.uriAfter() : null;
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/LocalStorageImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/LocalStorageImpl.java
@@ -266,7 +266,7 @@ final class LocalStorageImpl implements LocalStorage {
             final TokenWrapper tokenWrapper = tokenWrapperByKey.computeIfAbsent(key, TokenWrapper::new);
             final long stamp = tokenWrapper.lock.writeLock();
             try {
-                final ItemData previousItem = new ItemData(tokenWrapper.getValue(),
+                final TokenData previousItem = new TokenData(tokenWrapper.getValue(),
                         tokenWrapper.getUpdatedTimeMillis());
                 final String localToken = tokenWrapper.getValue();
                 if (!value.equals(localToken)) {
@@ -298,7 +298,7 @@ final class LocalStorageImpl implements LocalStorage {
                         throw new BrowserPageNotFoundException(
                                 "There is no active browser page in the session to remove the token");
                     }
-                    final ItemData previousItem = new ItemData(tokenWrapper.getValue(),
+                    final TokenData previousItem = new TokenData(tokenWrapper.getValue(),
                             tokenWrapper.getUpdatedTimeMillis());
                     if (tokenWrapperByKey.remove(key) != null) {
                         final int id = tokenIdGenerator.incrementAndGet();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -7014,8 +7014,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     throw new InvalidValueException("There is no existing whenURI condition at this index");
                 }
                 uriChangeContents.set(index, uriChangeContent);
-            }
-            lastURIPredicateTest = false;
+            }            
 
             final URIChangeTagSupplier uriChangeTagSupplier = sharedObject.getURIChangeTagSupplier(ACCESS_OBJECT);
             applyURIChange(uriChangeTagSupplier, true);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -1893,7 +1893,8 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
             while ((children = childrenStack.poll()) != null) {
 
                 for (final AbstractHtml eachChild : children) {
-                    final AbstractHtml[] innerHtmls = eachChild.changeInnerHtmlsForURIChange(currentURIEvent, updateClient);
+                    final AbstractHtml[] innerHtmls = eachChild.changeInnerHtmlsForURIChange(currentURIEvent,
+                            updateClient);
                     if (innerHtmls != null && innerHtmls.length > 0) {
                         childrenStack.push(List.of(innerHtmls));
                     } else if (eachChild.children != null && eachChild.children.size() > 0) {
@@ -6706,14 +6707,15 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriEventPredicate} test passed action will be performed on uri
-     * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriEventPredicate} test passes on URI change. <br>
+     * the first {@code uriEventPredicate} test passed action will be performed on
+     * uri change. The main intention of this method is to set children tags for
+     * this tag when the given {@code uriEventPredicate} test passes on URI change.
+     * <br>
      * Note: This method uses {@code null} for {@code failTagsSupplier}.
      *
-     * @param uriEventPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri details, if the test method
-     *                            returns true then the tags given by
+     * @param uriEventPredicate   the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the
+     *                            test method returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
      *                            given by {@code failTagsSupplier} will be added as
@@ -6747,14 +6749,15 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriEventPredicate} test passed action will be performed on uri
-     * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriEventPredicate} test passes on URI change. <br>
+     * the first {@code uriEventPredicate} test passed action will be performed on
+     * uri change. The main intention of this method is to set children tags for
+     * this tag when the given {@code uriEventPredicate} test passes on URI change.
+     * <br>
      * Note: This method uses {@code null} for {@code failTagsSupplier}.
      *
-     * @param uriEventPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri details, if the test method
-     *                            returns true then the tags given by
+     * @param uriEventPredicate   the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the
+     *                            test method returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
      *                            given by {@code failTagsSupplier} will be added as
@@ -6792,13 +6795,13 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriEventPredicate} test passed action will be performed on uri
-     * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriEventPredicate} test passes on URI change.
+     * the first {@code uriEventPredicate} test passed action will be performed on
+     * uri change. The main intention of this method is to set children tags for
+     * this tag when the given {@code uriEventPredicate} test passes on URI change.
      *
-     * @param uriEventPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri details, if the test method
-     *                            returns true then the tags given by
+     * @param uriEventPredicate   the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the
+     *                            test method returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
      *                            given by {@code failTagsSupplier} will be added as
@@ -6836,13 +6839,13 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriEventPredicate} test passed action will be performed on uri
-     * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriEventPredicate} test passes on URI change.
+     * the first {@code uriEventPredicate} test passed action will be performed on
+     * uri change. The main intention of this method is to set children tags for
+     * this tag when the given {@code uriEventPredicate} test passes on URI change.
      *
-     * @param uriEventPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri details, if the test method
-     *                            returns true then the tags given by
+     * @param uriEventPredicate   the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the
+     *                            test method returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
      *                            given by {@code failTagsSupplier} will be added as
@@ -6881,8 +6884,8 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
         Objects.requireNonNull(uriEventPredicate, "uriEventPredicate cannot be null in whenURI method");
         Objects.requireNonNull(successTagsSupplier, "successTagsSupplier cannot be null in whenURI method");
-        return whenURI(uriEventPredicate, successTagsSupplier, null, WhenURIMethodType.SUCCESS_SUPPLIER_FAIL_CONSUMER, null,
-                failConsumer, index);
+        return whenURI(uriEventPredicate, successTagsSupplier, null, WhenURIMethodType.SUCCESS_SUPPLIER_FAIL_CONSUMER,
+                null, failConsumer, index);
     }
 
     @Override
@@ -6891,8 +6894,8 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
         Objects.requireNonNull(uriEventPredicate, "uriEventPredicate cannot be null in whenURI method");
         Objects.requireNonNull(successTagsSupplier, "successTagsSupplier cannot be null in whenURI method");
-        return whenURI(uriEventPredicate, successTagsSupplier, null, WhenURIMethodType.SUCCESS_SUPPLIER_FAIL_CONSUMER, null,
-                failConsumer, -1);
+        return whenURI(uriEventPredicate, successTagsSupplier, null, WhenURIMethodType.SUCCESS_SUPPLIER_FAIL_CONSUMER,
+                null, failConsumer, -1);
     }
 
     @Override
@@ -6918,14 +6921,15 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
     /**
      *
      * @param uriEventPredicate
-     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
-     *                        returns true
-     * @param failConsumer    the consumer to execute if {@code uriEventPredicate.test()}
-     *                        returns false. {@code null} can be passed if there is
-     *                        no {@code failConsumer}.
-     * @param index           the position at which this action be the index to
-     *                        replace the existing action with this. A value less
-     *                        than zero will add this condition to the last.
+     * @param successConsumer   the consumer to execute if
+     *                          {@code uriEventPredicate.test()} returns true
+     * @param failConsumer      the consumer to execute if
+     *                          {@code uriEventPredicate.test()} returns false.
+     *                          {@code null} can be passed if there is no
+     *                          {@code failConsumer}.
+     * @param index             the position at which this action be the index to
+     *                          replace the existing action with this. A value less
+     *                          than zero will add this condition to the last.
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
@@ -6942,11 +6946,12 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
     /**
      *
      * @param uriEventPredicate
-     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
-     *                        returns true
-     * @param failConsumer    the consumer to execute if {@code uriEventPredicate.test()}
-     *                        returns false. {@code null} can be passed if there is
-     *                        no {@code failConsumer}.
+     * @param successConsumer   the consumer to execute if
+     *                          {@code uriEventPredicate.test()} returns true
+     * @param failConsumer      the consumer to execute if
+     *                          {@code uriEventPredicate.test()} returns false.
+     *                          {@code null} can be passed if there is no
+     *                          {@code failConsumer}.
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
@@ -6969,13 +6974,14 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
     /**
      *
      * @param uriEventPredicate
-     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
-     *                        returns true
+     * @param successConsumer   the consumer to execute if
+     *                          {@code uriEventPredicate.test()} returns true
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
     @Override
-    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer) {
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
+            final Consumer<TagEvent> successConsumer) {
         return whenURI(uriEventPredicate, successConsumer, (Consumer<TagEvent>) null, -1);
     }
 
@@ -7014,7 +7020,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     throw new InvalidValueException("There is no existing whenURI condition at this index");
                 }
                 uriChangeContents.set(index, uriChangeContent);
-            }            
+            }
 
             final URIChangeTagSupplier uriChangeTagSupplier = sharedObject.getURIChangeTagSupplier(ACCESS_OBJECT);
             applyURIChange(uriChangeTagSupplier, true);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -175,7 +175,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
     private volatile URIEvent lastURIEvent;
 
-    private volatile boolean lastURIPredicateTest;
+    private volatile Boolean lastURIPredicateTest = null;
 
     volatile long hierarchyOrder;
 
@@ -7037,7 +7037,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         try {
             uriChangeContents = null;
             lastURIEvent = null;
-            lastURIPredicateTest = false;
+            lastURIPredicateTest = null;
         } finally {
             lock.unlock();
         }
@@ -7059,7 +7059,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
             if (uriChangeContents.isEmpty()) {
                 uriChangeContents = null;
                 lastURIEvent = null;
-                lastURIPredicateTest = false;
+                lastURIPredicateTest = null;
             }
 
         } finally {
@@ -7120,7 +7120,8 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
         AbstractHtml[] insertedHtmls = null;
         final String lastURI = lastURIEvent != null ? lastURIEvent.uriAfter() : null;
-        if (uriChangeContents != null && uriEvent != null && uriEvent.uriAfter() != null && (!lastURIPredicateTest || !uriEvent.uriAfter().equals(lastURI))) {
+        if (uriChangeContents != null && uriEvent != null && uriEvent.uriAfter() != null
+                && ((lastURIPredicateTest != null && !lastURIPredicateTest) || !uriEvent.uriAfter().equals(lastURI))) {
 
             URIChangeContent lastUriChangeContent = null;
 
@@ -7182,7 +7183,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                         }
                     }
                 }
-                
+
                 lastURIEvent = uriEvent;
             }
         }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
@@ -15,5 +15,7 @@
  */
 package com.webfirmframework.wffweb.tag.html;
 
-public record TagEvent(AbstractHtml sourceTag, String uri) {
+import com.webfirmframework.wffweb.common.URIEvent;
+
+public record TagEvent(AbstractHtml sourceTag, URIEvent uriEvent) {
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
@@ -20,7 +20,7 @@ import com.webfirmframework.wffweb.common.URIEvent;
 public record TagEvent(AbstractHtml sourceTag, String uri, URIEvent uriEvent) {
 
     TagEvent(final AbstractHtml sourceTag, final URIEvent uriEvent) {
-        this(sourceTag, uriEvent.uriAfter(), uriEvent);
+        this(sourceTag, uriEvent != null ? uriEvent.uriAfter() : null, uriEvent);
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
@@ -17,5 +17,21 @@ package com.webfirmframework.wffweb.tag.html;
 
 import com.webfirmframework.wffweb.common.URIEvent;
 
-public record TagEvent(AbstractHtml sourceTag, URIEvent uriEvent) {
+public record TagEvent(AbstractHtml sourceTag, String uri, URIEvent uriEvent) {
+
+    TagEvent(final AbstractHtml sourceTag, final URIEvent uriEvent) {
+        this(sourceTag, uriEvent.uriAfter(), uriEvent);
+    }
+
+    /**
+     * @return the uri
+     * @deprecated This method will be removed in the next release, use
+     *             {@link #uriEvent()} and get the {@link URIEvent#uriAfter()}, i.e.
+     *             the current uri.
+     */
+    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
+    @Override
+    public String uri() {
+        return uri;
+    }
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
@@ -17,11 +17,7 @@ package com.webfirmframework.wffweb.tag.html;
 
 import com.webfirmframework.wffweb.common.URIEvent;
 
-public record TagEvent(AbstractHtml sourceTag, String uri, URIEvent uriEvent) {
-
-    TagEvent(final AbstractHtml sourceTag, final URIEvent uriEvent) {
-        this(sourceTag, uriEvent != null ? uriEvent.uriAfter() : null, uriEvent);
-    }
+public record TagEvent(AbstractHtml sourceTag, URIEvent uriEvent) {
 
     /**
      * @return the uri
@@ -30,8 +26,7 @@ public record TagEvent(AbstractHtml sourceTag, String uri, URIEvent uriEvent) {
      *             the current uri.
      */
     @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
-    @Override
     public String uri() {
-        return uri;
+        return uriEvent.uriAfter();
     }
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagUtil.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 
 import com.webfirmframework.wffweb.WffSecurityException;
+import com.webfirmframework.wffweb.common.URIEvent;
 import com.webfirmframework.wffweb.internal.ObjectId;
 import com.webfirmframework.wffweb.internal.constants.IndexedClassType;
 import com.webfirmframework.wffweb.internal.security.object.SecurityObject;
@@ -280,21 +281,21 @@ public final class TagUtil {
      * NB: only for internal use
      *
      * @param tag
-     * @param uri
+     * @param uriEvent
      * @param expectedSO
      * @param accessObject
-     * @since 12.0.0-beta.1
+     * @since 12.0.0-beta.5
      * @return true if sharedObjects are equals
      */
     @SuppressWarnings("exports")
-    public static boolean changeInnerHtmlsForURIChange(final AbstractHtml tag, final String uri,
+    public static boolean changeInnerHtmlsForURIChange(final AbstractHtml tag, final URIEvent uriEvent,
             final AbstractHtml5SharedObject expectedSO, final SecurityObject accessObject) {
 
         if (accessObject == null || !(IndexedClassType.BROWSER_PAGE.equals(accessObject.forClassType()))) {
             throw new WffSecurityException("Not allowed to consume this method. This method is for internal use.");
         }
 
-        return tag.changeInnerHtmlsForURIChange(uri, expectedSO);
+        return tag.changeInnerHtmlsForURIChange(uriEvent, expectedSO);
     }
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/URIStateSwitch.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/URIStateSwitch.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import com.webfirmframework.wffweb.common.URIEvent;
 import com.webfirmframework.wffweb.server.page.BrowserPage;
 
 /**
@@ -40,13 +41,13 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriPredicate} test passed action will be performed on uri
+     * the first {@code uriEventPredicate} test passed action will be performed on uri
      * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriPredicate} test passes on URI change. <br>
+     * tag when the given {@code uriEventPredicate} test passes on URI change. <br>
      * Note: This method uses {@code null} for {@code failTagsSupplier}.
      *
-     * @param uriPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri, if the test method
+     * @param uriEventPredicate        the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the test method
      *                            returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
@@ -55,14 +56,14 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      *                            {@code failTagsSupplier} is null the existing
      *                            children will be removed from this tag.
      * @param successTagsSupplier the supplier object for child tags if
-     *                            {@code uriPredicate} test returns true. If
+     *                            {@code uriEventPredicate} test returns true. If
      *                            {@code successTagsSupplier.get()} method returns
      *                            null, no action will be done on the tag.
      *
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Supplier<AbstractHtml[]> successTagsSupplier);
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Supplier<AbstractHtml[]> successTagsSupplier);
 
     /**
      * Replaces the children of this tag with the tags supplied by
@@ -77,13 +78,13 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriPredicate} test passed action will be performed on uri
+     * the first {@code uriEventPredicate} test passed action will be performed on uri
      * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriPredicate} test passes on URI change. <br>
+     * tag when the given {@code uriEventPredicate} test passes on URI change. <br>
      * Note: This method uses {@code null} for {@code failTagsSupplier}.
      *
-     * @param uriPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri, if the test method
+     * @param uriEventPredicate        the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the test method
      *                            returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
@@ -92,7 +93,7 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      *                            {@code failTagsSupplier} is null the existing
      *                            children will be removed from this tag.
      * @param successTagsSupplier the supplier object for child tags if
-     *                            {@code uriPredicate} test returns true. If
+     *                            {@code uriEventPredicate} test returns true. If
      *                            {@code successTagsSupplier.get()} method returns
      *                            null, no action will be done on the tag.
      *
@@ -103,7 +104,7 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
             final int index);
 
     /**
@@ -119,12 +120,12 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriPredicate} test passed action will be performed on uri
+     * the first {@code uriEventPredicate} test passed action will be performed on uri
      * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriPredicate} test passes on URI change.
+     * tag when the given {@code uriEventPredicate} test passes on URI change.
      *
-     * @param uriPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri, if the test method
+     * @param uriEventPredicate        the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the test method
      *                            returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
@@ -133,18 +134,18 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      *                            {@code failTagsSupplier} is null the existing
      *                            children will be removed from this tag.
      * @param successTagsSupplier the supplier object for child tags if
-     *                            {@code uriPredicate} test returns true. If
+     *                            {@code uriEventPredicate} test returns true. If
      *                            {@code successTagsSupplier.get()} method returns
      *                            null, no action will be done on the tag.
      * @param failTagsSupplier    the supplier object for child tags if
-     *                            {@code uriPredicate} test returns false. If
+     *                            {@code uriEventPredicate} test returns false. If
      *                            {@code failTagsSupplier.get()} * method returns
      *                            null, no action will be done on the tag.
      *
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
             final Supplier<AbstractHtml[]> failTagsSupplier);
 
     /**
@@ -160,12 +161,12 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * multiple times to set multiple actions,
      * {@link AbstractHtml#removeURIChangeAction(int)} may be used to remove each
      * action at the given index. If multiple actions are added by this method, only
-     * the first {@code uriPredicate} test passed action will be performed on uri
+     * the first {@code uriEventPredicate} test passed action will be performed on uri
      * change. The main intention of this method is to set children tags for this
-     * tag when the given {@code uriPredicate} test passes on URI change.
+     * tag when the given {@code uriEventPredicate} test passes on URI change.
      *
-     * @param uriPredicate        the predicate object to test, the argument of the
-     *                            test method is the changed uri, if the test method
+     * @param uriEventPredicate        the predicate object to test, the argument of the
+     *                            test method is the changed uri details, if the test method
      *                            returns true then the tags given by
      *                            {@code successTagsSupplier} will be added as inner
      *                            html to this tag. If test returns false, the tags
@@ -174,11 +175,11 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      *                            {@code failTagsSupplier} is null the existing
      *                            children will be removed from this tag.
      * @param successTagsSupplier the supplier object for child tags if
-     *                            {@code uriPredicate} test returns true. If
+     *                            {@code uriEventPredicate} test returns true. If
      *                            {@code successTagsSupplier.get()} method returns
      *                            null, no action will be done on the tag.
      * @param failTagsSupplier    the supplier object for child tags if
-     *                            {@code uriPredicate} test returns false. If
+     *                            {@code uriEventPredicate} test returns false. If
      *                            {@code failTagsSupplier.get()} * method returns
      *                            null, no action will be done on the tag.
      * @param index               the index to replace the existing action with
@@ -187,27 +188,27 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
             final Supplier<AbstractHtml[]> failTagsSupplier, final int index);
 
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
             final Consumer<TagEvent> failConsumer, final int index);
 
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Supplier<AbstractHtml[]> successTagsSupplier,
             final Consumer<TagEvent> failConsumer);
 
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Supplier<AbstractHtml[]> failTagsSupplier, final int index);
 
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Supplier<AbstractHtml[]> failTagsSupplier);
 
     /**
      *
-     * @param uriPredicate
-     * @param successConsumer the consumer to execute if {@code uriPredicate.test()}
+     * @param uriEventPredicate
+     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
      *                        returns true
-     * @param failConsumer    the consumer to execute if {@code uriPredicate.test()}
+     * @param failConsumer    the consumer to execute if {@code uriEventPredicate.test()}
      *                        returns false. {@code null} can be passed if there is
      *                        no {@code failConsumer}.
      * @param index           the position at which this action be the index to
@@ -216,26 +217,26 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Consumer<TagEvent> failConsumer, final int index);
 
     /**
-     * @param uriPredicate
-     * @param successConsumer the consumer to execute if {@code uriPredicate.test()}
+     * @param uriEventPredicate
+     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
      *                        returns true
-     * @param failConsumer    the consumer to execute if {@code uriPredicate.test()}
+     * @param failConsumer    the consumer to execute if {@code uriEventPredicate.test()}
      *                        returns false. {@code null} can be passed if there is
      *                        no {@code failConsumer}.
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Consumer<TagEvent> failConsumer);
 
     /**
      *
-     * @param uriPredicate
-     * @param successConsumer the consumer to execute if {@code uriPredicate.test()}
+     * @param uriEventPredicate
+     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
      *                        returns true *
      * @param index           the position at which this action be the index to
      *                        replace the existing action with this. A value less
@@ -243,17 +244,17 @@ public sealed interface URIStateSwitch permits AbstractHtml {
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final int index);
 
     /**
-     * @param uriPredicate
-     * @param successConsumer the consumer to execute if {@code uriPredicate.test()}
+     * @param uriEventPredicate
+     * @param successConsumer the consumer to execute if {@code uriEventPredicate.test()}
      *                        returns true
      * @return URIStateSwitch
      * @since 12.0.0-beta.1
      */
-    URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer);
+    URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer);
 
     /**
      * Removes all whenURI actions.

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -1003,7 +1003,9 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      * @return true if the given ownerTag is an owner of the attribute.
      * @author WFF
      * @since 2.0.0
+     * @deprecated it is only for the internal purpose
      */
+    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
     public boolean unsetOwnerTag(final AbstractHtml ownerTag) {
         final long stamp = ownerTagsLock.writeLock();
         final boolean result;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attributewff/ImmutableCustomAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attributewff/ImmutableCustomAttribute.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014-2022 Web Firm Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * @author WFF
+ */
+package com.webfirmframework.wffweb.tag.html.attributewff;
+
+import com.webfirmframework.wffweb.NullValueException;
+import com.webfirmframework.wffweb.tag.html.attribute.core.AbstractAttribute;
+import com.webfirmframework.wffweb.tag.html.identifier.GlobalAttributable;
+
+/**
+ * This is a custom attribute to create an attribute with any name and value.
+ *
+ * @author WFF
+ * @since 12.0.0-beta.5
+ */
+public class ImmutableCustomAttribute extends AbstractAttribute implements GlobalAttributable {
+
+    private static final long serialVersionUID = 1_0_0L;
+
+    {
+        init();
+    }
+
+    /**
+     * @param attributeName the name for the attribute
+     * @since 12.0.0-beta.5
+     */
+    public ImmutableCustomAttribute(final String attributeName) {
+        if (attributeName == null) {
+            throw new NullValueException("attributeName can not be null");
+        }
+        super.setAttributeName(attributeName);
+        setAttributeValue(null);
+    }
+
+    /**
+     * @param attributeName the name for the attribute
+     * @param value         the value for the attribute
+     * @since 12.0.0-beta.5
+     */
+    public ImmutableCustomAttribute(final String attributeName, final String value) {
+        if (attributeName == null) {
+            throw new NullValueException("attributeName can not be null");
+        }
+        super.setAttributeName(attributeName);
+        setAttributeValue(value);
+    }
+
+    /**
+     * invokes only once per object
+     *
+     * @author WFF
+     * @since 12.0.0-beta.5
+     */
+    protected void init() {
+        // to override and use this method
+    }
+
+    /**
+     * @return the value
+     * @author WFF
+     * @since 12.0.0-beta.5
+     */
+    public String getValue() {
+        return getAttributeValue();
+    }
+
+}

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/NoTag.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/NoTag.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import com.webfirmframework.wffweb.MethodNotImplementedException;
+import com.webfirmframework.wffweb.common.URIEvent;
 import com.webfirmframework.wffweb.tag.html.AbstractHtml;
 import com.webfirmframework.wffweb.tag.html.SharedTagContent;
 import com.webfirmframework.wffweb.tag.html.TagEvent;
@@ -252,7 +253,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
     }
@@ -261,7 +262,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final int index) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
     }
@@ -270,7 +271,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Supplier<AbstractHtml[]> failTagsSupplier) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
     }
@@ -279,7 +280,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Supplier<AbstractHtml[]> failTagsSupplier,
             final int index) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
@@ -289,7 +290,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Consumer<TagEvent> failConsumer,
             final int index) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
@@ -299,7 +300,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Consumer<TagEvent> failConsumer) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
     }
@@ -308,7 +309,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Supplier<AbstractHtml[]> failTagsSupplier, final int index) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
     }
@@ -317,7 +318,7 @@ public class NoTag extends AbstractHtml {
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
     @Deprecated(since = "12.0.0-beta.1")
-    public URIStateSwitch whenURI(final Predicate<String> uriPredicate, final Consumer<TagEvent> successConsumer,
+    public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Supplier<AbstractHtml[]> failTagsSupplier) {
         throw new MethodNotImplementedException("This method is not allowed in NoTag");
     }

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffAsync.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffAsync.js
@@ -188,7 +188,7 @@ window.wffAsync = new function() {
 	};
 
 };
-
+wffGlobal.frz(window.wffAsync, false);
 // sample usage
 //
 // wffAsync.serverMethod('methodName', {'key1':'hi'}).invoke(function(obj) {

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffAsync.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffAsync.js
@@ -79,7 +79,7 @@ window.wffAsync = new function() {
 	};
 
 
-	var setServerURIWithCallback = function(uri, callback, initiator) {
+	var setServerURIWithCallbackPvt = function(uri, callback, initiator, rplc) {
 
 		var taskNameValue = wffTaskUtil.getTaskNameValue(
 			wffGlobal.taskValues.TASK,
@@ -88,13 +88,14 @@ window.wffAsync = new function() {
 			'name': encoder.encode(uri),
 			'values': []
 		};
+		var rplcByt = rplc ? 1 : 0;
 		//NB: should be checked as undefined as its value could be zero
 		if (typeof initiator !== "undefined" && initiator >= 0 && initiator < wffGlobal.uriEventInitiator.size) {
-			nameValue.values.push([initiator]);
+			nameValue.values.push([initiator, rplcByt]);
 		} else {
-			nameValue.values.push([wffGlobal.uriEventInitiator.CLIENT_CODE]);
+			nameValue.values.push([wffGlobal.uriEventInitiator.CLIENT_CODE, rplcByt]);
 		}
-			
+
 		var nameValues = [taskNameValue, nameValue];
 
 		if (callback) {
@@ -105,7 +106,7 @@ window.wffAsync = new function() {
 				'name': encoder.encode(callbackFunId),
 				'values': []
 			};
-			
+
 			nameValues.push(nameValueCallbackFun);
 		}
 
@@ -113,32 +114,41 @@ window.wffAsync = new function() {
 		wffWS.send(wffBM);
 	};
 
-	this.setServerURIWithCallback = setServerURIWithCallback;
+	this.setServerURIWithCallback = function(uri, callback, initiator) {setServerURIWithCallbackPvt(uri, callback, initiator, false);};
 
-	this.setServerURI = function(uri) { setServerURIWithCallback(uri, undefined, wffGlobal.uriEventInitiator.CLIENT_CODE); };
+	this.setServerURI = function(uri) { setServerURIWithCallbackPvt(uri, undefined, wffGlobal.uriEventInitiator.CLIENT_CODE, false); };
 
 	var throwInvalidSetURIArgException = function() {
 		throw "Invalid argument found in setURI function call. " +
-		"Eg: wffAsync.setURI('/sampleuri', function(e){console.log('uri changed');}, function(e){console.log('uri changed, after server change');});, " +
-		"wffAsync.setURI('/sampleuri', function(e){console.log('uri changed');}); or " +
-		"wffAsync.setURI('/sampleuri');";
+		"Eg: wffAsync.setURI('/sampleuri', function(e){console.log('uri changed');}, function(e){console.log('uri changed, after server change');}, false);, " +
+		"wffAsync.setURI('/sampleuri', function(e){console.log('uri changed');}, function(e){console.log('uri changed, after server change');});, " +
+		"wffAsync.setURI('/sampleuri', function(e){console.log('uri changed');});, " +
+		"wffAsync.setURI('/sampleuri'); or " +
+		"wffAsync.setURI('/sampleuri', null, null, false);";
 	};
 
-	this.setURI = function(uri, onSetURI, afterSetURI) {
+	this.setURI = function(uri, onSetURI, afterSetURI, replace) {
 
-		if (typeof onSetURI !== "undefined" && typeof onSetURI !== "function") {
+		if (typeof onSetURI !== "undefined" && onSetURI !== null && typeof onSetURI !== "function") {
 			throwInvalidSetURIArgException();
 		}
-
-		if (typeof afterSetURI !== "undefined" && typeof afterSetURI !== "function") {
+		if (typeof afterSetURI !== "undefined" && afterSetURI !== null && typeof afterSetURI !== "function") {
+			throwInvalidSetURIArgException();
+		}
+		if (typeof replace !== "undefined" && replace !== null && typeof replace !== "boolean") {
 			throwInvalidSetURIArgException();
 		}
 
 		var uriBefore = window.location.pathname;
-		history.pushState({}, document.title, uri);
+		if (replace) {
+			history.replaceState({}, document.title, uri);
+		} else {
+			history.pushState({}, document.title, uri);
+		}
+
 		var uriAfter = window.location.pathname;
 		if (uriBefore !== uriAfter) {
-			var wffEvent = { uriBefore: uriBefore, uriAfter: uriAfter, origin: "client", initiator: 'clientCode' };
+			var wffEvent = { uriBefore: uriBefore, uriAfter: uriAfter, origin: "client", initiator: 'clientCode', replace: replace ? true : false };
 
 			var callbackWrapper = afterSetURI;
 
@@ -154,7 +164,6 @@ window.wffAsync = new function() {
 				var afterSetURIGlobal = wffGlobalListeners.afterSetURI;
 
 				if (afterSetURIGlobal) {
-					
 					callbackWrapper = function() {
 						if (afterSetURI) {
 							try {
@@ -169,7 +178,6 @@ window.wffAsync = new function() {
 						} catch (e) {
 							wffLog("wffGlobalListeners.afterSetURI threw exception when wffAsync.setURI is called", e);
 						}
-
 					};
 				}
 
@@ -183,7 +191,7 @@ window.wffAsync = new function() {
 				wffLog("The second argument threw exception when wffAsync.setURI is called", e);
 			}
 			//NB: should be uriAfter to be consistent with uri pattern
-			setServerURIWithCallback(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.CLIENT_CODE);
+			setServerURIWithCallbackPvt(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.CLIENT_CODE, replace);
 		}
 	};
 

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMCRUIDUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMCRUIDUtil.js
@@ -142,3 +142,5 @@ var wffBMCRUIDUtil = new function() {
 	
 
 };
+
+wffGlobal.frz(wffBMCRUIDUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMClientEvents.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMClientEvents.js
@@ -1,4 +1,3 @@
-
 var wffBMClientEvents = new function() {
 
 	window.wffRemovePrevBPInstanceInvoked = false;
@@ -109,5 +108,5 @@ var wffBMClientEvents = new function() {
 		wffWS.send(wffBM);
 	};
 
-
 };
+wffGlobal.frz(wffBMClientEvents, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMUtil.js
@@ -395,3 +395,4 @@ var wffBMUtil = new function() {
 	this.getDoubleFromOptimizedBytes = getDoubleFromOptimizedBytes;
 
 };
+wffGlobal.frz(wffBMUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientCRUDUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientCRUDUtil.js
@@ -1,7 +1,3 @@
-/**
- * 
- */
-
 var wffClientCRUDUtil = new function() {
 
 	var encoder = wffGlobal.encoder;
@@ -850,3 +846,4 @@ var wffClientCRUDUtil = new function() {
 	};
 
 };
+wffGlobal.frz(wffClientCRUDUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientCRUDUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientCRUDUtil.js
@@ -470,19 +470,25 @@ var wffClientCRUDUtil = new function() {
 			jsObj.uriAfter = jsObj.ua;
 			jsObj.uriBefore = jsObj.ub;
 			jsObj.origin = jsObj.o;
+			jsObj.replace = jsObj.r;
 			delete jsObj.ua;
 			delete jsObj.ub;
 			delete jsObj.o;
+			delete jsObj.r;
 			if (jsObj.uriAfter && jsObj.uriAfter !== jsObj.uriBefore) {
 				if (jsObj.origin === 'S') {
 					jsObj.origin = 'server';
 					jsObj.initiator = 'serverCode';
-				} 
+				}
 				var vnt = {};
 				for (k in jsObj) {
 					vnt[k] = jsObj[k];
 				}
-				history.pushState({}, document.title, jsObj.uriAfter);
+				if (jsObj.replace) {
+					history.replaceState({}, document.title, jsObj.uriAfter);
+				} else {
+					history.pushState({}, document.title, jsObj.uriAfter);
+				}
 				uriChangeQ.push(vnt);
 				if (typeof wffGlobalListeners !== "undefined" && wffGlobalListeners.onSetURI && jsObj.origin === 'server') {
 					try {
@@ -495,7 +501,7 @@ var wffClientCRUDUtil = new function() {
 		} else if (taskValue == wffGlobal.taskValues.AFTER_SET_URI) {
 			if (typeof wffGlobalListeners !== "undefined" && wffGlobalListeners.afterSetURI) {
 				for (var i = 0; i < uriChangeQ.length; i++) {
-					var vnt = uriChangeQ[i];					
+					var vnt = uriChangeQ[i];
 					try {
 						wffGlobalListeners.afterSetURI(vnt);
 					} catch (e) {

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientMethods.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientMethods.js
@@ -70,3 +70,4 @@ var wffClientMethods = new function() {
 		return true;
 	};
 };
+wffGlobal.frz(wffClientMethods, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffGlobal.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffGlobal.js
@@ -114,10 +114,18 @@ window.wffGlobal = new function() {
 		this.decoder = new TextDecoder("utf-8");
 	}
 
-	this.freeze = function(obj) {
-		if ((typeof Object) !== "undefined" && Object.freeze) {
-			Object.freeze(obj);
+	//args: obj, deep freeze
+	var frz = ((typeof Object) !== "undefined" && Object.freeze) ? function(obj, d) {
+		if (d) {
+			for (var k in obj) {
+				var v = obj[k];
+				if (v && typeof v === "object") {
+					frz(v, d);
+				}
+			}
 		}
-	};
+		return Object.freeze(obj);
+	} : function(o, d) { };
+	this.frz = frz;
 };
-wffGlobal.freeze(wffGlobal);
+wffGlobal.frz(wffGlobal, true);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffServerMethods.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffServerMethods.js
@@ -200,3 +200,7 @@ var wffServerMethods = new function () {
 //never ever rename ia
 var wffSM = wffServerMethods;
 
+wffGlobal.frz(wffTaskUtil, false);
+wffGlobal.frz(wffSM, false);
+
+

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffTagUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffTagUtil.js
@@ -368,3 +368,4 @@ var wffTagUtil = new function() {
 	};
 	
 };
+wffGlobal.frz(wffTagUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffWS.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffWS.js
@@ -185,3 +185,4 @@ var wffWS = new function() {
 		return -1;
 	};
 };
+wffGlobal.frz(wffWS, false);

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/common/test/AllTests.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/common/test/AllTests.java
@@ -153,6 +153,7 @@ import com.webfirmframework.wffweb.tag.html.attribute.core.AttributeRegistryTest
 import com.webfirmframework.wffweb.tag.html.attribute.core.AttributeUtilTest;
 import com.webfirmframework.wffweb.tag.html.attribute.global.ClassAttributeTest;
 import com.webfirmframework.wffweb.tag.html.attribute.global.StyleTest;
+import com.webfirmframework.wffweb.tag.html.attributewff.ImmutableCustomAttributeTest;
 import com.webfirmframework.wffweb.tag.html.core.TagRegistryTest;
 import com.webfirmframework.wffweb.tag.html.formsandinputs.FormTest;
 import com.webfirmframework.wffweb.tag.html.formsandinputs.InputTest;
@@ -220,7 +221,8 @@ import com.webfirmframework.wffweb.wffbm.data.WffBMObjectArrayTest;
         StringBuilderUtilTest.class, SecurityClassConstantsTest.class, ReentrantStampedLockTest.class,
         UnicodeStringTest.class, ExternalDriveByteArrayQueueTest.class, ExternalDriveClientTasksWrapperDequeTest.class,
         ExternalDriveClientTasksWrapperQueueTest.class, AttributeIdGeneratorTest.class,
-        SharedObjectIdGeneratorTest.class, WhenURIUseCaseTest.class, URIUtilTest.class, EventInitiatorTest.class })
+        SharedObjectIdGeneratorTest.class, WhenURIUseCaseTest.class, URIUtilTest.class, EventInitiatorTest.class,
+        ImmutableCustomAttributeTest.class })
 public class AllTests {
 
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFileTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFileTest.java
@@ -51,7 +51,7 @@ public class WffJsFileTest {
             k += 1;}
             A.length = len;return A;};}());}window.wffGlobal = new function() {
             var wffId = -1;this.getUniqueWffIntId = function() {
-            return ++wffId;};this.CPRSD_DATA = true;this.NDXD_TGS = ["#","@","a","b","i","p","q","s","u","br","dd","dl","dt","em","h1","h2","h3","h4","h5","h6","hr","li","ol","rp","rt","td","th","tr","ul","bdi","bdo","col","del","dfn","div","img","ins","kbd","map","nav","pre","qfn","sub","sup","svg","var","wbr","abbr","area","base","body","cite","code","data","form","head","html","line","link","main","mark","math","menu","meta","path","rect","ruby","samp","span","text","time","aside","audio","embed","input","label","meter","param","small","style","table","tbody","tfoot","thead","title","track","video","button","canvas","circle","dialog","figure","footer","header","hgroup","iframe","keygen","legend","object","option","output","script","select","source","strong","address","article","caption","details","ellipse","picture","polygon","section","summary","basefont","colgroup","datalist","fieldset","menuitem","noscript","optgroup","polyline","progress","template","textarea","blockquote","figcaption"];this.NDXD_ATRBS = ["id","alt","dir","for","low","max","min","rel","rev","src","cols","face","form","high","href","lang","list","loop","name","open","role","rows","size","step","type","wrap","align","async","class","color","defer","ismap","media","muted","nonce","oncut","scope","shape","sizes","style","title","value","width","accept","action","border","coords","height","hidden","method","nohref","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","poster","sorted","srcset","target","usemap","charset","checked","colspan","content","default","dirname","enctype","headers","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","optimum","pattern","preload","rowspan","sandbox","autoplay","controls","datetime","disabled","download","dropzone","hreflang","multiple","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","readonly","required","reversed","selected","tabindex","accesskey","autofocus","draggable","maxlength","minlength","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","translate","formaction","formmethod","formtarget","http-equiv","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","spellcheck","cellpadding","cellspacing","contextmenu","data-wff-id","formenctype","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","placeholder","animationend","autocomplete","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","transitionend","accept-charset","animationstart","formnovalidate","onbeforeunload","onvolumechange","contenteditable","oncanplaythrough","ondurationchange","onloadedmetadata","animationiteration"];this.NDXD_VNT_ATRBS = ["oncut","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","onbeforeunload","onvolumechange","oncanplaythrough","ondurationchange","onloadedmetadata"];this.NDXD_BLN_ATRBS = ["open","async","defer","ismap","hidden","checked","default","controls","disabled","multiple","readonly","reversed","selected"];this.taskValues = {INITIAL_WS_OPEN:0,INVOKE_ASYNC_METHOD:1,ATTRIBUTE_UPDATED:2,TASK:3,APPENDED_CHILD_TAG:4,REMOVED_TAGS:5,APPENDED_CHILDREN_TAGS:6,REMOVED_ALL_CHILDREN_TAGS:7,MOVED_CHILDREN_TAGS:8,INSERTED_BEFORE_TAG:9,INSERTED_AFTER_TAG:10,REPLACED_WITH_TAGS:11,REMOVED_ATTRIBUTES:12,ADDED_ATTRIBUTES:13,MANY_TO_ONE:14,ONE_TO_MANY:15,MANY_TO_MANY:16,ONE_TO_ONE:17,ADDED_INNER_HTML:18,INVOKE_POST_FUNCTION:19,EXEC_JS:20,RELOAD_BROWSER:21,RELOAD_BROWSER_FROM_CACHE:22,INVOKE_CALLBACK_FUNCTION:23,INVOKE_CUSTOM_SERVER_METHOD:24,TASK_OF_TASKS:25,COPY_INNER_TEXT_TO_VALUE:26,REMOVE_BROWSER_PAGE:27,SET_BM_OBJ_ON_TAG:28,SET_BM_ARR_ON_TAG:29,DEL_BM_OBJ_OR_ARR_FROM_TAG:30,CLIENT_PATHNAME_CHANGED:31,AFTER_SET_URI:32,SET_URI:33,SET_LS_ITEM:34,SET_LS_TOKEN:35,GET_LS_ITEM:36,REMOVE_LS_ITEM:37,REMOVE_LS_TOKEN:38,REMOVE_AND_GET_LS_ITEM:39,CLEAR_LS:40};this.uriEventInitiator = {SERVER_CODE:0,CLIENT_CODE:1,BROWSER:2,size:3};this.WS_URL = "ws://webfirmframework.com";this.INSTANCE_ID = "instance-id-1234585-451";this.NODE_ID = "675b3a95-63b5-490f-a626-491ba8fe8185";this.REMOVE_PREV_BP_ON_INITTAB = true;this.REMOVE_PREV_BP_ON_TABCLOSE = true;this.WS_RECON = 2000;if ((typeof TextEncoder) === "undefined") {
+            return ++wffId;};this.CPRSD_DATA = true;this.NDXD_TGS = ["#","@","a","b","i","p","q","s","u","br","dd","dl","dt","em","h1","h2","h3","h4","h5","h6","hr","li","ol","rp","rt","td","th","tr","ul","bdi","bdo","col","del","dfn","div","img","ins","kbd","map","nav","pre","qfn","sub","sup","svg","var","wbr","abbr","area","base","body","cite","code","data","form","head","html","line","link","main","mark","math","menu","meta","path","rect","ruby","samp","span","text","time","aside","audio","embed","input","label","meter","param","small","style","table","tbody","tfoot","thead","title","track","video","button","canvas","circle","dialog","figure","footer","header","hgroup","iframe","keygen","legend","object","option","output","script","select","source","strong","address","article","caption","details","ellipse","picture","polygon","section","summary","basefont","colgroup","datalist","fieldset","menuitem","noscript","optgroup","polyline","progress","template","textarea","blockquote","figcaption"];this.NDXD_ATRBS = ["id","alt","dir","for","low","max","min","rel","rev","src","cols","face","form","high","href","lang","list","loop","name","open","role","rows","size","step","type","wrap","align","async","class","color","defer","ismap","media","muted","nonce","oncut","scope","shape","sizes","style","title","value","width","accept","action","border","coords","height","hidden","method","nohref","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","poster","sorted","srcset","target","usemap","charset","checked","colspan","content","default","dirname","enctype","headers","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","optimum","pattern","preload","rowspan","sandbox","autoplay","controls","datetime","disabled","download","dropzone","hreflang","multiple","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","readonly","required","reversed","selected","tabindex","accesskey","autofocus","draggable","maxlength","minlength","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","translate","formaction","formmethod","formtarget","http-equiv","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","spellcheck","cellpadding","cellspacing","contextmenu","data-wff-id","formenctype","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","placeholder","animationend","autocomplete","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","transitionend","accept-charset","animationstart","formnovalidate","onbeforeunload","onvolumechange","contenteditable","oncanplaythrough","ondurationchange","onloadedmetadata","animationiteration"];this.NDXD_VNT_ATRBS = ["oncut","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","onbeforeunload","onvolumechange","oncanplaythrough","ondurationchange","onloadedmetadata"];this.NDXD_BLN_ATRBS = ["open","async","defer","ismap","hidden","checked","default","controls","disabled","multiple","readonly","reversed","selected"];this.taskValues = {INITIAL_WS_OPEN:0,INVOKE_ASYNC_METHOD:1,ATTRIBUTE_UPDATED:2,TASK:3,APPENDED_CHILD_TAG:4,REMOVED_TAGS:5,APPENDED_CHILDREN_TAGS:6,REMOVED_ALL_CHILDREN_TAGS:7,MOVED_CHILDREN_TAGS:8,INSERTED_BEFORE_TAG:9,INSERTED_AFTER_TAG:10,REPLACED_WITH_TAGS:11,REMOVED_ATTRIBUTES:12,ADDED_ATTRIBUTES:13,MANY_TO_ONE:14,ONE_TO_MANY:15,MANY_TO_MANY:16,ONE_TO_ONE:17,ADDED_INNER_HTML:18,INVOKE_POST_FUNCTION:19,EXEC_JS:20,RELOAD_BROWSER:21,RELOAD_BROWSER_FROM_CACHE:22,INVOKE_CALLBACK_FUNCTION:23,INVOKE_CUSTOM_SERVER_METHOD:24,TASK_OF_TASKS:25,COPY_INNER_TEXT_TO_VALUE:26,REMOVE_BROWSER_PAGE:27,SET_BM_OBJ_ON_TAG:28,SET_BM_ARR_ON_TAG:29,DEL_BM_OBJ_OR_ARR_FROM_TAG:30,CLIENT_PATHNAME_CHANGED:31,AFTER_SET_URI:32,SET_URI:33,SET_LS_ITEM:34,SET_LS_TOKEN:35,GET_LS_ITEM:36,REMOVE_LS_ITEM:37,REMOVE_LS_TOKEN:38,REMOVE_AND_GET_LS_ITEM:39,CLEAR_LS:40};this.uriEventInitiator = {SERVER_CODE:0,CLIENT_CODE:1,BROWSER:2,size:3};this.WS_URL = "ws://webfirmframework.com";this.INSTANCE_ID = "instance-id-1234585-451";this.NODE_ID = "8c7626b4-28c7-4a86-b032-ce14f9cf3d90";this.REMOVE_PREV_BP_ON_INITTAB = true;this.REMOVE_PREV_BP_ON_TABCLOSE = true;this.WS_RECON = 2000;if ((typeof TextEncoder) === "undefined") {
             this.encoder = new function TextEncoder(charset) {
             if (charset === "utf-8") {
             this.encode = function(text) {
@@ -93,10 +93,14 @@ public class WffJsFileTest {
             return text;};}
             }("utf-8");} else {
             this.decoder = new TextDecoder("utf-8");}
-            this.freeze = function(obj) {
-            if ((typeof Object) !== "undefined" && Object.freeze) {
-            Object.freeze(obj);}
-            };};wffGlobal.freeze(wffGlobal);var wffBMUtil = new function(){
+            var frz = ((typeof Object) !== "undefined" && Object.freeze) ? function(obj, d) {
+            if (d) {
+            for (var k in obj) {
+            var v = obj[k];if (v && typeof v === "object") {
+            frz(v, d);}
+            }
+            }
+            return Object.freeze(obj);} : function(o, d) { };this.frz = frz;};wffGlobal.frz(wffGlobal, true);var wffBMUtil = new function(){
 
             this.f13 = function(v76){
             var v34 = 0;var v22 = 0;for (var i = 0; i < v76.length; i++){
@@ -193,7 +197,7 @@ public class WffJsFileTest {
             var f8 = function(bytes){
             var buffer = new ArrayBuffer(8);var int8Array = new Int8Array(buffer);for (var i = 0; i < bytes.length; i++){
             int8Array[i] = bytes[bytes.length - 1 - i];}
-            return new Float64Array(buffer)[0];};this.f8 = f8;};
+            return new Float64Array(buffer)[0];};this.f8 = f8;};wffGlobal.frz(wffBMUtil, false);
             var wffTagUtil = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f30 = function(utf8Bytes){
             return decoder.decode(new Uint8Array(utf8Bytes));};var subarray = wffBMUtil.subarray;var f5 = function(utf8Bytes){
@@ -271,7 +275,7 @@ public class WffJsFileTest {
             return parent;};if(wffGlobal.CPRSD_DATA){
             this.f18 = this.f2;}
             this.f21 = function(p, v20){
-            var i = wffBMUtil.f14(v20);return p.childNodes[i];};};
+            var i = wffBMUtil.f14(v20);return p.childNodes[i];};};wffGlobal.frz(wffTagUtil, false);
             var wffBMCRUIDUtil = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var encodedBytesForHash = encoder.encode('#');this.f17 = function(tag){
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("DT");var v46 = {
@@ -311,7 +315,7 @@ public class WffJsFileTest {
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("C");var v46 = {
             'name' : tUtf8Bytes,
             'values' : [ cUtf8Bytes ]
-            };v76.push(v46);var v61 = 0;f43(v76, tag, v61);v76[1].name = wffBMUtil.f15(v41);return wffBMUtil.f13(v76);};};
+            };v76.push(v46);var v61 = 0;f43(v76, tag, v61);v76[1].name = wffBMUtil.f15(v41);return wffBMUtil.f13(v76);};};wffGlobal.frz(wffBMCRUIDUtil, false);
             var wffClientCRUDUtil = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var uriChangeQ = [];var f30 = function(utf8Bytes){
             return decoder.decode(new Uint8Array(utf8Bytes));};var f44 = function(v76){
@@ -592,7 +596,7 @@ public class WffJsFileTest {
             }else{
             return false;}
             return true;};this.f29 = function(v79){
-            var v84 = wffBMUtil.f9(v79)[1];};};
+            var v84 = wffBMUtil.f9(v79)[1];};};wffGlobal.frz(wffClientCRUDUtil, false);
             var wffTaskUtil = new function (){
             var encoder = wffGlobal.encoder;this.f34 = function(v93, valueByte){
             var v46 = {
@@ -644,7 +648,7 @@ public class WffJsFileTest {
             event.preventDefault();}
             var v46 = wffTaskUtil.f34(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f24(v70);var jsObject = filterFun(event, tag);var v32 = new WffBMObject(jsObject);var v94 = v32.getBMBytes();var v84 = {'name':wffTagUtil.f25(tag), 'values':[v88, v94]};var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};this.d = function(event, tag, v70, filterFun){
             f10(event, tag, v70, filterFun, true);};var invokeAsyncWithFilterFun = function(event, tag, v70, filterFun){
-            f10(event, tag, v70, filterFun, false);};this.c = invokeAsyncWithFilterFun;};var wffSM = wffServerMethods;
+            f10(event, tag, v70, filterFun, false);};this.c = invokeAsyncWithFilterFun;};var wffSM = wffServerMethods;wffGlobal.frz(wffTaskUtil, false);wffGlobal.frz(wffSM, false);
             var wffClientMethods = new function(){
             var f30 = function(utf8Bytes){
             return wffGlobal.decoder.decode(new Uint8Array(utf8Bytes));};this.exePostFun = function(v79){
@@ -666,7 +670,7 @@ public class WffJsFileTest {
             }
             cbFun(jsObject);delete wffAsync.v27[funKey];}else{
             return false;}
-            return true;};};
+            return true;};};wffGlobal.frz(wffClientMethods, false);
             var f35 = function(valueType){
             if(valueType === '[object String]'){
             return 0;}else if(valueType === '[object Number]'){
@@ -924,7 +928,7 @@ public class WffJsFileTest {
             } catch (e){
             wffLog("The second argument threw exception when wffAsync.setURI is called", e);}
             setServerURIWithCallback(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.CLIENT_CODE);}
-            };};
+            };};wffGlobal.frz(window.wffAsync, false);
             var wffBMClientEvents = new function(){
             window.v1 = false;var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f27 = function(wffInstanceId){
             var v76 = [];var v23 = encoder.encode(wffInstanceId);var tnv = wffTaskUtil.f34(
@@ -961,7 +965,7 @@ public class WffJsFileTest {
             'values': [bmBts]
             };v76.push(nv);}
             }
-            var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};};
+            var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};};wffGlobal.frz(wffBMClientEvents, false);
             var wffWS = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var prevIntvl = null;var webSocket = null;var inDataQ = [];var sendQData = null;this.openSocket = function(wsUrl){
             if(webSocket !== null
@@ -1024,7 +1028,7 @@ public class WffJsFileTest {
             };this.getState = function(){
             if(webSocket !== null){
             return webSocket.readyState;}
-            return -1;};};
+            return -1;};};wffGlobal.frz(wffWS, false);
             document.addEventListener("DOMContentLoaded",
             function(event){
             var encoder = wffGlobal.encoder;if(typeof window.f37Invoked === 'undefined'){

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFileTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFileTest.java
@@ -51,7 +51,7 @@ public class WffJsFileTest {
             k += 1;}
             A.length = len;return A;};}());}window.wffGlobal = new function() {
             var wffId = -1;this.getUniqueWffIntId = function() {
-            return ++wffId;};this.CPRSD_DATA = true;this.NDXD_TGS = ["#","@","a","b","i","p","q","s","u","br","dd","dl","dt","em","h1","h2","h3","h4","h5","h6","hr","li","ol","rp","rt","td","th","tr","ul","bdi","bdo","col","del","dfn","div","img","ins","kbd","map","nav","pre","qfn","sub","sup","svg","var","wbr","abbr","area","base","body","cite","code","data","form","head","html","line","link","main","mark","math","menu","meta","path","rect","ruby","samp","span","text","time","aside","audio","embed","input","label","meter","param","small","style","table","tbody","tfoot","thead","title","track","video","button","canvas","circle","dialog","figure","footer","header","hgroup","iframe","keygen","legend","object","option","output","script","select","source","strong","address","article","caption","details","ellipse","picture","polygon","section","summary","basefont","colgroup","datalist","fieldset","menuitem","noscript","optgroup","polyline","progress","template","textarea","blockquote","figcaption"];this.NDXD_ATRBS = ["id","alt","dir","for","low","max","min","rel","rev","src","cols","face","form","high","href","lang","list","loop","name","open","role","rows","size","step","type","wrap","align","async","class","color","defer","ismap","media","muted","nonce","oncut","scope","shape","sizes","style","title","value","width","accept","action","border","coords","height","hidden","method","nohref","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","poster","sorted","srcset","target","usemap","charset","checked","colspan","content","default","dirname","enctype","headers","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","optimum","pattern","preload","rowspan","sandbox","autoplay","controls","datetime","disabled","download","dropzone","hreflang","multiple","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","readonly","required","reversed","selected","tabindex","accesskey","autofocus","draggable","maxlength","minlength","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","translate","formaction","formmethod","formtarget","http-equiv","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","spellcheck","cellpadding","cellspacing","contextmenu","data-wff-id","formenctype","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","placeholder","animationend","autocomplete","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","transitionend","accept-charset","animationstart","formnovalidate","onbeforeunload","onvolumechange","contenteditable","oncanplaythrough","ondurationchange","onloadedmetadata","animationiteration"];this.NDXD_VNT_ATRBS = ["oncut","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","onbeforeunload","onvolumechange","oncanplaythrough","ondurationchange","onloadedmetadata"];this.NDXD_BLN_ATRBS = ["open","async","defer","ismap","hidden","checked","default","controls","disabled","multiple","readonly","reversed","selected"];this.taskValues = {INITIAL_WS_OPEN:0,INVOKE_ASYNC_METHOD:1,ATTRIBUTE_UPDATED:2,TASK:3,APPENDED_CHILD_TAG:4,REMOVED_TAGS:5,APPENDED_CHILDREN_TAGS:6,REMOVED_ALL_CHILDREN_TAGS:7,MOVED_CHILDREN_TAGS:8,INSERTED_BEFORE_TAG:9,INSERTED_AFTER_TAG:10,REPLACED_WITH_TAGS:11,REMOVED_ATTRIBUTES:12,ADDED_ATTRIBUTES:13,MANY_TO_ONE:14,ONE_TO_MANY:15,MANY_TO_MANY:16,ONE_TO_ONE:17,ADDED_INNER_HTML:18,INVOKE_POST_FUNCTION:19,EXEC_JS:20,RELOAD_BROWSER:21,RELOAD_BROWSER_FROM_CACHE:22,INVOKE_CALLBACK_FUNCTION:23,INVOKE_CUSTOM_SERVER_METHOD:24,TASK_OF_TASKS:25,COPY_INNER_TEXT_TO_VALUE:26,REMOVE_BROWSER_PAGE:27,SET_BM_OBJ_ON_TAG:28,SET_BM_ARR_ON_TAG:29,DEL_BM_OBJ_OR_ARR_FROM_TAG:30,CLIENT_PATHNAME_CHANGED:31,AFTER_SET_URI:32,SET_URI:33,SET_LS_ITEM:34,SET_LS_TOKEN:35,GET_LS_ITEM:36,REMOVE_LS_ITEM:37,REMOVE_LS_TOKEN:38,REMOVE_AND_GET_LS_ITEM:39,CLEAR_LS:40};this.uriEventInitiator = {SERVER_CODE:0,CLIENT_CODE:1,BROWSER:2,size:3};this.WS_URL = "ws://webfirmframework.com";this.INSTANCE_ID = "instance-id-1234585-451";this.NODE_ID = "8c7626b4-28c7-4a86-b032-ce14f9cf3d90";this.REMOVE_PREV_BP_ON_INITTAB = true;this.REMOVE_PREV_BP_ON_TABCLOSE = true;this.WS_RECON = 2000;if ((typeof TextEncoder) === "undefined") {
+            return ++wffId;};this.CPRSD_DATA = true;this.NDXD_TGS = ["#","@","a","b","i","p","q","s","u","br","dd","dl","dt","em","h1","h2","h3","h4","h5","h6","hr","li","ol","rp","rt","td","th","tr","ul","bdi","bdo","col","del","dfn","div","img","ins","kbd","map","nav","pre","qfn","sub","sup","svg","var","wbr","abbr","area","base","body","cite","code","data","form","head","html","line","link","main","mark","math","menu","meta","path","rect","ruby","samp","span","text","time","aside","audio","embed","input","label","meter","param","small","style","table","tbody","tfoot","thead","title","track","video","button","canvas","circle","dialog","figure","footer","header","hgroup","iframe","keygen","legend","object","option","output","script","select","source","strong","address","article","caption","details","ellipse","picture","polygon","section","summary","basefont","colgroup","datalist","fieldset","menuitem","noscript","optgroup","polyline","progress","template","textarea","blockquote","figcaption"];this.NDXD_ATRBS = ["id","alt","dir","for","low","max","min","rel","rev","src","cols","face","form","high","href","lang","list","loop","name","open","role","rows","size","step","type","wrap","align","async","class","color","defer","ismap","media","muted","nonce","oncut","scope","shape","sizes","style","title","value","width","accept","action","border","coords","height","hidden","method","nohref","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","poster","sorted","srcset","target","usemap","charset","checked","colspan","content","default","dirname","enctype","headers","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","optimum","pattern","preload","rowspan","sandbox","autoplay","controls","datetime","disabled","download","dropzone","hreflang","multiple","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","readonly","required","reversed","selected","tabindex","accesskey","autofocus","draggable","maxlength","minlength","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","translate","formaction","formmethod","formtarget","http-equiv","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","spellcheck","cellpadding","cellspacing","contextmenu","data-wff-id","formenctype","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","placeholder","animationend","autocomplete","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","transitionend","accept-charset","animationstart","formnovalidate","onbeforeunload","onvolumechange","contenteditable","oncanplaythrough","ondurationchange","onloadedmetadata","animationiteration"];this.NDXD_VNT_ATRBS = ["oncut","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","onbeforeunload","onvolumechange","oncanplaythrough","ondurationchange","onloadedmetadata"];this.NDXD_BLN_ATRBS = ["open","async","defer","ismap","hidden","checked","default","controls","disabled","multiple","readonly","reversed","selected"];this.taskValues = {INITIAL_WS_OPEN:0,INVOKE_ASYNC_METHOD:1,ATTRIBUTE_UPDATED:2,TASK:3,APPENDED_CHILD_TAG:4,REMOVED_TAGS:5,APPENDED_CHILDREN_TAGS:6,REMOVED_ALL_CHILDREN_TAGS:7,MOVED_CHILDREN_TAGS:8,INSERTED_BEFORE_TAG:9,INSERTED_AFTER_TAG:10,REPLACED_WITH_TAGS:11,REMOVED_ATTRIBUTES:12,ADDED_ATTRIBUTES:13,MANY_TO_ONE:14,ONE_TO_MANY:15,MANY_TO_MANY:16,ONE_TO_ONE:17,ADDED_INNER_HTML:18,INVOKE_POST_FUNCTION:19,EXEC_JS:20,RELOAD_BROWSER:21,RELOAD_BROWSER_FROM_CACHE:22,INVOKE_CALLBACK_FUNCTION:23,INVOKE_CUSTOM_SERVER_METHOD:24,TASK_OF_TASKS:25,COPY_INNER_TEXT_TO_VALUE:26,REMOVE_BROWSER_PAGE:27,SET_BM_OBJ_ON_TAG:28,SET_BM_ARR_ON_TAG:29,DEL_BM_OBJ_OR_ARR_FROM_TAG:30,CLIENT_PATHNAME_CHANGED:31,AFTER_SET_URI:32,SET_URI:33,SET_LS_ITEM:34,SET_LS_TOKEN:35,GET_LS_ITEM:36,REMOVE_LS_ITEM:37,REMOVE_LS_TOKEN:38,REMOVE_AND_GET_LS_ITEM:39,CLEAR_LS:40};this.uriEventInitiator = {SERVER_CODE:0,CLIENT_CODE:1,BROWSER:2,size:3};this.WS_URL = "ws://webfirmframework.com";this.INSTANCE_ID = "instance-id-1234585-451";this.NODE_ID = "ec19a8a5-8d25-4ac1-83f6-19b0845556d2";this.REMOVE_PREV_BP_ON_INITTAB = true;this.REMOVE_PREV_BP_ON_TABCLOSE = true;this.WS_RECON = 2000;if ((typeof TextEncoder) === "undefined") {
             this.encoder = new function TextEncoder(charset) {
             if (charset === "utf-8") {
             this.encode = function(text) {
@@ -102,7 +102,7 @@ public class WffJsFileTest {
             }
             return Object.freeze(obj);} : function(o, d) { };this.frz = frz;};wffGlobal.frz(wffGlobal, true);var wffBMUtil = new function(){
 
-            this.f13 = function(v76){
+            this.f14 = function(v76){
             var v34 = 0;var v22 = 0;for (var i = 0; i < v76.length; i++){
             var name = v76[i].name;var values = v76[i].values;if(name.length > v34){
             v34 = name.length;}
@@ -114,34 +114,34 @@ public class WffJsFileTest {
             v22 = v3;}
             }
             var v14 = f3(v34);var v12 = f3(v22);var v11 = [];v11.push(v14);v11.push(v12);for (var i = 0; i < v76.length; i++){
-            var name = v76[i].name;var v43 = f28(name.length,
-            v14);f33(v11, v43);f33(v11, name);var values = v76[i].values;if(values.length == 0){
-            f33(v11, f28(0,
+            var name = v76[i].name;var v43 = f29(name.length,
+            v14);f34(v11, v43);f34(v11, name);var values = v76[i].values;if(values.length == 0){
+            f34(v11, f29(0,
             v12));}else{
             var v72 = 0;for (var l = 0; l < values.length; l++){
             v72 += values[l].length;}
-            v72 += (v12 * values.length);var v37 = f28(v72,
-            v12);f33(v11, v37);for (var m = 0; m < values.length; m++){
-            var value = values[m];v37 = f28(value.length,
-            v12);f33(v11, v37);f33(v11, value);}
+            v72 += (v12 * values.length);var v37 = f29(v72,
+            v12);f34(v11, v37);for (var m = 0; m < values.length; m++){
+            var value = values[m];v37 = f29(value.length,
+            v12);f34(v11, v37);f34(v11, value);}
             }
             }
-            return v11;};this.f9 = function(message){
+            return v11;};this.f10 = function(message){
             var v76 = [];var v10 = message[0];var v8 = message[1];for (var v57 = 2; v57 < message.length; v57++){
             var v84 = {};var v39 = subarray(message,
-            v57, v10);v57 = v57 + v10;var v48 = f14(v39);var v85 = subarray(message, v57,
+            v57, v10);v57 = v57 + v10;var v48 = f15(v39);var v85 = subarray(message, v57,
             v48);v57 = v57 + v85.length;v84.name = v85;var v35 = subarray(message,
-            v57, v8);v57 = v57 + v8;v48 = f14(v35);var v77 = subarray(message, v57,
+            v57, v8);v57 = v57 + v8;v48 = f15(v35);var v77 = subarray(message, v57,
             v48);v57 = v57 + v77.length - 1;var v9 = f7(
             v8, v77);v84.values = v9;v76.push(v84);}
             return v76;};
             var f7 = function(v8, v77){
             var values = [];for (var i = 0; i < v77.length; i++){
             var v35 = subarray(v77, i,
-            v8);var v66 = f14(v35);var value = subarray(v77, i
+            v8);var v66 = f15(v35);var value = subarray(v77, i
             + v8, v66);values.push(value);i = i + v8 + v66 - 1;}
             return values;};
-            var f33 = function(v52, v40){
+            var f34 = function(v52, v40){
             for (var a = 0; a < v40.length; a++){
             v52.push(v40[a]);}
             };
@@ -155,12 +155,12 @@ public class WffJsFileTest {
             var sub = [];for (var i = pos; i < upto; i++){
             sub.push(srcAry[i]);}
             return sub;};this.subarray = subarray;
-            var f38 = function(bytes){
+            var f39 = function(bytes){
             return bytes[0] << 24 | (bytes[1] & 0xFF) << 16
             | (bytes[2] & 0xFF) << 8 | (bytes[3] & 0xFF);};
-            var f39 = function(value){
+            var f40 = function(value){
             var bytes = [ (value >> 24), (value >> 16), (value >> 8), value ];return bytes;};
-            var f14 = function(bytes){
+            var f15 = function(bytes){
             if(bytes.length == 4){
             return bytes[0] << 24 | (bytes[1] & 0xFF) << 16
             | (bytes[2] & 0xFF) << 8 | (bytes[3] & 0xFF);}else if(bytes.length == 3){
@@ -169,15 +169,15 @@ public class WffJsFileTest {
             return (bytes[0] & 0xFF) << 8 | (bytes[1] & 0xFF);}else if(bytes.length == 1){
             return (bytes[0] & 0xFF);}
             return bytes[0] << 24 | (bytes[1] & 0xFF) << 16
-            | (bytes[2] & 0xFF) << 8 | (bytes[3] & 0xFF);};this.f14 = f14;
-            var f15 = function(value){
+            | (bytes[2] & 0xFF) << 8 | (bytes[3] & 0xFF);};this.f15 = f15;
+            var f16 = function(value){
             var v65 = (value >> 24);var v80 = (value >> 16);var v67 = (value >> 8);var v71 = value;if(v65 == 0){
             if(v80 == 0){
             if(v67 == 0){
             return [ v71 ];}
             return [ v67, v71 ];}
             return [ v80, v67, v71 ];}
-            return [ v65, v80, v67, v71 ];};this.f15 = f15;
+            return [ v65, v80, v67, v71 ];};this.f16 = f16;
             var f3 = function(value){
             var v65 = (value >> 24);var v80 = (value >> 16);var v67 = (value >> 8);var v71 = value;if(v65 == 0){
             if(v80 == 0){
@@ -186,113 +186,113 @@ public class WffJsFileTest {
             return 2;}
             return 3;}
             return 4;};
-            var f28 = function(value, v53){
+            var f29 = function(value, v53){
             var v65 = (value >> 24);var v80 = (value >> 16);var v67 = (value >> 8);var v71 = value;if(v53 == 1){
             return [ v71 ];}else if(v53 == 2){
             return [ v67, v71 ];}else if(v53 == 3){
             return [ v80, v67, v71 ];}
             return [ v65, v80, v67, v71 ];};
-            var f32 = function(v62){
-            var arrayBuff = new ArrayBuffer(8);var float64 = new Float64Array(arrayBuff);float64[0] = v62;var uin = new Int8Array(arrayBuff);return Array.from(uin).reverse();};this.f32 = f32;
+            var f33 = function(v62){
+            var arrayBuff = new ArrayBuffer(8);var float64 = new Float64Array(arrayBuff);float64[0] = v62;var uin = new Int8Array(arrayBuff);return Array.from(uin).reverse();};this.f33 = f33;
             var f8 = function(bytes){
             var buffer = new ArrayBuffer(8);var int8Array = new Int8Array(buffer);for (var i = 0; i < bytes.length; i++){
             int8Array[i] = bytes[bytes.length - 1 - i];}
             return new Float64Array(buffer)[0];};this.f8 = f8;};wffGlobal.frz(wffBMUtil, false);
             var wffTagUtil = new function(){
-            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f30 = function(utf8Bytes){
+            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f31 = function(utf8Bytes){
             return decoder.decode(new Uint8Array(utf8Bytes));};var subarray = wffBMUtil.subarray;var f5 = function(utf8Bytes){
             if(utf8Bytes.length == 1){
-            var v95 = wffBMUtil.f14(utf8Bytes);return wffGlobal.NDXD_TGS[v95];}
+            var v95 = wffBMUtil.f15(utf8Bytes);return wffGlobal.NDXD_TGS[v95];}
             var v7 = utf8Bytes[0];if(v7 > 0){
-            var v26 = subarray(utf8Bytes, 1, v7);var v95 = wffBMUtil.f14(v26);return wffGlobal.NDXD_TGS[v95];}else{
-            var v60 = utf8Bytes.length - 1;var v59 = subarray(utf8Bytes, 1, v60);return f30(v59);}
+            var v26 = subarray(utf8Bytes, 1, v7);var v95 = wffBMUtil.f15(v26);return wffGlobal.NDXD_TGS[v95];}else{
+            var v60 = utf8Bytes.length - 1;var v59 = subarray(utf8Bytes, 1, v60);return f31(v59);}
             };this.f5 = f5;var getAttrNameFromCompressedBytes = function(utf8Bytes){
             if(utf8Bytes.length == 1){
-            var v82 = wffBMUtil.f14(utf8Bytes);return wffGlobal.NDXD_ATRBS[v82];}
+            var v82 = wffBMUtil.f15(utf8Bytes);return wffGlobal.NDXD_ATRBS[v82];}
             var v5 = utf8Bytes[0];if(v5 > 0){
-            var v19 = subarray(utf8Bytes, 1, v5);var v82 = wffBMUtil.f14(v19);return wffGlobal.NDXD_ATRBS[v82];}else{
-            var v60 = utf8Bytes.length - 1;var v91Bytes = subarray(utf8Bytes, 1, v60);return f30(v91Bytes);}
+            var v19 = subarray(utf8Bytes, 1, v5);var v82 = wffBMUtil.f15(v19);return wffGlobal.NDXD_ATRBS[v82];}else{
+            var v60 = utf8Bytes.length - 1;var v91Bytes = subarray(utf8Bytes, 1, v60);return f31(v91Bytes);}
             };this.getAttrNameFromCompressedBytes = getAttrNameFromCompressedBytes;var f1 = function(utf8Bytes){
             var v5 = utf8Bytes[0];if(v5 > 0){
-            var v19 = subarray(utf8Bytes, 1, v5);var v82 = wffBMUtil.f14(v19);var v83 = utf8Bytes.length - (v5 + 1);var v68 = subarray(utf8Bytes, v5 + 1, v83);var attrNamVal = [wffGlobal.NDXD_ATRBS[v82], f30(v68)];return attrNamVal;}else{
-            var v60 = utf8Bytes.length - 1;var v69 = subarray(utf8Bytes, 1, v60);return f31(f30(v69));}
-            };this.f1 = f1;var f26 = function(tag, htmlString){
+            var v19 = subarray(utf8Bytes, 1, v5);var v82 = wffBMUtil.f15(v19);var v83 = utf8Bytes.length - (v5 + 1);var v68 = subarray(utf8Bytes, v5 + 1, v83);var attrNamVal = [wffGlobal.NDXD_ATRBS[v82], f31(v68)];return attrNamVal;}else{
+            var v60 = utf8Bytes.length - 1;var v69 = subarray(utf8Bytes, 1, v60);return f32(f31(v69));}
+            };this.f1 = f1;var f27 = function(tag, htmlString){
             var tmpDv = document.createElement('div');tmpDv.innerHTML = htmlString;for (var i = 0; i < tmpDv.childNodes.length; i++){
             var cn = tmpDv.childNodes[i];if(cn.nodeName === '#text'){
             tag.appendChild(document.createTextNode(cn.nodeValue));}else{
             tag.appendChild(cn.cloneNode(true));}
             }
-            };this.f16 = function(tagName, v98){
+            };this.f17 = function(tagName, v99){
             var elements = document.querySelectorAll(tagName + '[data-wff-id="'
-            + v98 + '"]');if(elements.length > 1){
-            wffLog('multiple tags with same wff id', 'tagName', 'v98', v98);}
-            return elements[0];};this.f40 = function(v98){
-            var elements = document.querySelectorAll('[data-wff-id="' + v98
+            + v99 + '"]');if(elements.length > 1){
+            wffLog('multiple tags with same wff id', 'tagName', 'v99', v99);}
+            return elements[0];};this.f41 = function(v99){
+            var elements = document.querySelectorAll('[data-wff-id="' + v99
             + '"]');if(elements.length > 1){
-            wffLog('multiple tags with same wff id', 'v98', v98);}
+            wffLog('multiple tags with same wff id', 'v99', v99);}
             return elements[0];};
-            this.f23 = function(v75){
-            var v100 = f30([ v75[0] ]);var intBytes = [];for (var i = 1; i < v75.length; i++){
+            this.f24 = function(v75){
+            var v101 = f31([ v75[0] ]);var intBytes = [];for (var i = 1; i < v75.length; i++){
             intBytes.push(v75[i]);}
-            var v99 = wffBMUtil.f14(intBytes);return v100 + v99;};this.f25 = function(tag){
+            var v100 = wffBMUtil.f15(intBytes);return v101 + v100;};this.f26 = function(tag){
             var v87 = tag.getAttribute("data-wff-id");if(v87 == null){
             v87 = "C" + wffGlobal.getUniqueWffIntId();tag.setAttribute("data-wff-id", v87);}
-            var v100 = v87.substring(0, 1);var v51 = encoder.encode(v100);var v75 = [ v51[0] ];var v99 = v87.substring(1, v87.length);var v74 = wffBMUtil.f15(parseInt(v99));v75 = v75.concat(v74);return v75;};var f31 = function(v56){
+            var v101 = v87.substring(0, 1);var v51 = encoder.encode(v101);var v75 = [ v51[0] ];var v100 = v87.substring(1, v87.length);var v74 = wffBMUtil.f16(parseInt(v100));v75 = v75.concat(v74);return v75;};var f32 = function(v56){
             var v91;var v87;var v31 = v56.indexOf('=');if(v31 != -1){
             v91 = v56.substring(0, v31);v87 = v56.substring(v31 + 1,
             v56.length);}else{
             v91 = v56;v87 = '';}
-            return [ v91, v87 ];};this.f31 = f31;this.f18 = function(bytes){
-            var v76 = wffBMUtil.f9(bytes);var v16 = v76[0];var v29 = v16.values;var v96 = [];var parent;var v54 = f30(v29[0]);if(v54 === '#'){
-            var text = f30(v29[1]);parent = document.createDocumentFragment();parent.appendChild(document.createTextNode(text));}else if(v54 === '@'){
-            var text = f30(v29[1]);parent = document.createDocumentFragment();f26(parent, text);}else{
+            return [ v91, v87 ];};this.f32 = f32;this.f19 = function(bytes){
+            var v76 = wffBMUtil.f10(bytes);var v16 = v76[0];var v29 = v16.values;var v96 = [];var parent;var v54 = f31(v29[0]);if(v54 === '#'){
+            var text = f31(v29[1]);parent = document.createDocumentFragment();parent.appendChild(document.createTextNode(text));}else if(v54 === '@'){
+            var text = f31(v29[1]);parent = document.createDocumentFragment();f27(parent, text);}else{
             parent = document.createElement(v54);for (var i = 1; i < v29.length; i++){
-            var v56 = f31(f30(v29[i]));parent[v56[0]] = v56[1];parent.setAttribute(v56[0], v56[1]);}
+            var v56 = f32(f31(v29[i]));parent[v56[0]] = v56[1];parent.setAttribute(v56[0], v56[1]);}
             }
             v96.push(parent);for (var i = 1; i < v76.length; i++){
-            var name = v76[i].name;var values = v76[i].values;var tagName = f30(values[0]);var child;if(tagName === '#'){
-            var text = f30(values[1]);child = document.createDocumentFragment();child.appendChild(document.createTextNode(text));}else if(tagName === '@'){
-            var text = f30(values[1]);child = document.createDocumentFragment();f26(child, text);}else{
+            var name = v76[i].name;var values = v76[i].values;var tagName = f31(values[0]);var child;if(tagName === '#'){
+            var text = f31(values[1]);child = document.createDocumentFragment();child.appendChild(document.createTextNode(text));}else if(tagName === '@'){
+            var text = f31(values[1]);child = document.createDocumentFragment();f27(child, text);}else{
             child = document.createElement(tagName);for (var j = 1; j < values.length; j++){
-            var v56 = f31(f30(values[j]));child[v56[0]] = v56[1];child.setAttribute(v56[0], v56[1]);}
+            var v56 = f32(f31(values[j]));child[v56[0]] = v56[1];child.setAttribute(v56[0], v56[1]);}
             }
-            v96.push(child);var v61 = wffBMUtil.f14(name);v96[v61].appendChild(child);}
+            v96.push(child);var v61 = wffBMUtil.f15(name);v96[v61].appendChild(child);}
             return parent;};this.f2 = function(bytes){
-            var v76 = wffBMUtil.f9(bytes);var v16 = v76[0];var v29 = v16.values;var v96 = [];var parent;var v54 = f5(v29[0]);if(v54 === '#'){
-            var text = f30(v29[1]);parent = document.createDocumentFragment();parent.appendChild(document.createTextNode(text));}else if(v54 === '@'){
-            var text = f30(v29[1]);parent = document.createDocumentFragment();f26(parent, text);}else{
+            var v76 = wffBMUtil.f10(bytes);var v16 = v76[0];var v29 = v16.values;var v96 = [];var parent;var v54 = f5(v29[0]);if(v54 === '#'){
+            var text = f31(v29[1]);parent = document.createDocumentFragment();parent.appendChild(document.createTextNode(text));}else if(v54 === '@'){
+            var text = f31(v29[1]);parent = document.createDocumentFragment();f27(parent, text);}else{
             parent = document.createElement(v54);for (var i = 1; i < v29.length; i++){
             var v56 = f1(v29[i]);parent[v56[0]] = v56[1];parent.setAttribute(v56[0], v56[1]);}
             }
             v96.push(parent);for (var i = 1; i < v76.length; i++){
             var name = v76[i].name;var values = v76[i].values;var tagName = f5(values[0]);var child;if(tagName === '#'){
-            var text = f30(values[1]);child = document.createDocumentFragment();child.appendChild(document.createTextNode(text));}else if(tagName === '@'){
-            var text = f30(values[1]);child = document.createDocumentFragment();f26(child, text);}else{
+            var text = f31(values[1]);child = document.createDocumentFragment();child.appendChild(document.createTextNode(text));}else if(tagName === '@'){
+            var text = f31(values[1]);child = document.createDocumentFragment();f27(child, text);}else{
             child = document.createElement(tagName);for (var j = 1; j < values.length; j++){
             var v56 = f1(values[j]);child[v56[0]] = v56[1];child.setAttribute(v56[0], v56[1]);}
             }
-            v96.push(child);var v61 = wffBMUtil.f14(name);v96[v61].appendChild(child);}
+            v96.push(child);var v61 = wffBMUtil.f15(name);v96[v61].appendChild(child);}
             return parent;};if(wffGlobal.CPRSD_DATA){
-            this.f18 = this.f2;}
-            this.f21 = function(p, v20){
-            var i = wffBMUtil.f14(v20);return p.childNodes[i];};};wffGlobal.frz(wffTagUtil, false);
+            this.f19 = this.f2;}
+            this.f22 = function(p, v20){
+            var i = wffBMUtil.f15(v20);return p.childNodes[i];};};wffGlobal.frz(wffTagUtil, false);
             var wffBMCRUIDUtil = new function(){
-            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var encodedBytesForHash = encoder.encode('#');this.f17 = function(tag){
+            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var encodedBytesForHash = encoder.encode('#');this.f18 = function(tag){
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("DT");var v46 = {
             'name' : tUtf8Bytes,
             'values' : [ cUtf8Bytes ]
-            };v76.push(v46);var v90 = wffTagUtil.f25(tag);var v84 = {
+            };v76.push(v46);var v90 = wffTagUtil.f26(tag);var v84 = {
             'name' : v90,
             'values' : []
-            };v76.push(v84);return wffBMUtil.f13(v76);};this.f12 = function(v91, v87, v64){
+            };v76.push(v84);return wffBMUtil.f14(v76);};this.f13 = function(v91, v87, v64){
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("UA");var v46 = {
             'name' : tUtf8Bytes,
             'values' : [ cUtf8Bytes ]
             };v76.push(v46);var v24 = encoder.encode(v91 + "="
             + v87);var v84 = {
-            'name' : wffBMUtil.f15(v64),
+            'name' : wffBMUtil.f16(v64),
             'values' : [ v24 ]
-            };v76.push(v84);return wffBMUtil.f13(v76);};var f43 = function(v76, tag, v61){
+            };v76.push(v84);return wffBMUtil.f14(v76);};var f44 = function(v76, tag, v61){
             var v6 = v61 + 1;var nodeName = tag.nodeName;if(nodeName != '#text'){
             var values = [];var v55 = encoder.encode(nodeName);values.push(v55);for (var i = 0; i < tag.attributes.length; i++){
             var attribute = tag.attributes[i];var v13;if(attribute.value != null){
@@ -302,78 +302,78 @@ public class WffJsFileTest {
             .encode(attribute.name);}
             values.push(v13);}
             var v84 = {
-            'name' : wffBMUtil.f15(v61),
+            'name' : wffBMUtil.f16(v61),
             'values' : values
             };v76.push(v84);}else{
             var v44 = encoder.encode(tag.nodeValue);var values = [ encodedBytesForHash, v44 ];var v84 = {
-            'name' : wffBMUtil.f15(v61),
+            'name' : wffBMUtil.f16(v61),
             'values' : values
             };v76.push(v84);}
             v61++;for (var i = 0; i < tag.childNodes.length; i++){
-            f43(v76, tag.childNodes[i], v61);}
-            };this.f19 = function(tag, v41){
+            f44(v76, tag.childNodes[i], v61);}
+            };this.f20 = function(tag, v41){
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("C");var v46 = {
             'name' : tUtf8Bytes,
             'values' : [ cUtf8Bytes ]
-            };v76.push(v46);var v61 = 0;f43(v76, tag, v61);v76[1].name = wffBMUtil.f15(v41);return wffBMUtil.f13(v76);};};wffGlobal.frz(wffBMCRUIDUtil, false);
+            };v76.push(v46);var v61 = 0;f44(v76, tag, v61);v76[1].name = wffBMUtil.f16(v41);return wffBMUtil.f14(v76);};};wffGlobal.frz(wffBMCRUIDUtil, false);
             var wffClientCRUDUtil = new function(){
-            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var uriChangeQ = [];var f30 = function(utf8Bytes){
-            return decoder.decode(new Uint8Array(utf8Bytes));};var f44 = function(v76){
+            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var uriChangeQ = [];var f31 = function(utf8Bytes){
+            return decoder.decode(new Uint8Array(utf8Bytes));};var f45 = function(v76){
             var v46 = v76[0];var taskValue = v46.values[0][0];if(taskValue == wffGlobal.taskValues.ATTRIBUTE_UPDATED){
             for (var i = 1; i < v76.length; i++){
-            var v56 = wffTagUtil.f1(v76[i].name);var v91 = v56[0];var v87 = v56[1];var v97 = v76[i].values;for (var j = 0; j < v97.length; j++){
-            var v98 = wffTagUtil.f23(v97[j]);var v49 = wffTagUtil.f40(v98);v49[v91] = v87;v49.setAttribute(v91, v87);}
+            var v56 = wffTagUtil.f1(v76[i].name);var v91 = v56[0];var v87 = v56[1];var v98 = v76[i].values;for (var j = 0; j < v98.length; j++){
+            var v99 = wffTagUtil.f24(v98[j]);var v49 = wffTagUtil.f41(v99);v49[v91] = v87;v49.setAttribute(v91, v87);}
             }
             }
             else if(taskValue == wffGlobal.taskValues.APPENDED_CHILD_TAG
             || taskValue == wffGlobal.taskValues.APPENDED_CHILDREN_TAGS){
             for (var i = 1; i < v76.length; i++){
-            var v98 = wffTagUtil
-            .f23(v76[i].name);var values = v76[i].values;var tagName = wffTagUtil.f5(values[0]);var parent = wffTagUtil.f16(tagName, v98);for (var j = 1; j < values.length; j++){
+            var v99 = wffTagUtil
+            .f24(v76[i].name);var values = v76[i].values;var tagName = wffTagUtil.f5(values[0]);var parent = wffTagUtil.f17(tagName, v99);for (var j = 1; j < values.length; j++){
             var v89 = wffTagUtil
-            .f18(values[j]);parent.appendChild(v89);}
+            .f19(values[j]);parent.appendChild(v89);}
             }
             }else if(taskValue == wffGlobal.taskValues.REMOVED_TAGS){
             for (var i = 1; i < v76.length; i++){
-            var v98 = wffTagUtil
-            .f23(v76[i].name);var values = v76[i].values;var tagName = wffTagUtil.f5(values[0]);var v63 = wffTagUtil.f16(tagName,
-            v98);var parent = v63.parentNode;parent.removeChild(v63);}
+            var v99 = wffTagUtil
+            .f24(v76[i].name);var values = v76[i].values;var tagName = wffTagUtil.f5(values[0]);var v63 = wffTagUtil.f17(tagName,
+            v99);var parent = v63.parentNode;parent.removeChild(v63);}
             }else if(taskValue == wffGlobal.taskValues.REMOVED_ALL_CHILDREN_TAGS){
             for (var i = 1; i < v76.length; i++){
-            var v98 = wffTagUtil
-            .f23(v76[i].name);var values = v76[i].values;var tagName = wffTagUtil.f5(values[0]);var parentTag = wffTagUtil.f16(tagName,
-            v98);while (parentTag.firstChild){
+            var v99 = wffTagUtil
+            .f24(v76[i].name);var values = v76[i].values;var tagName = wffTagUtil.f5(values[0]);var parentTag = wffTagUtil.f17(tagName,
+            v99);while (parentTag.firstChild){
             parentTag.removeChild(parentTag.firstChild);}
             }
             }else if(taskValue == wffGlobal.taskValues.MOVED_CHILDREN_TAGS){
             for (var i = 1; i < v76.length; i++){
             var v25 = wffTagUtil
-            .f23(v76[i].name);var values = v76[i].values;var v17 = wffTagUtil.f5(values[0]);var v33 = wffTagUtil.f16(
+            .f24(v76[i].name);var values = v76[i].values;var v17 = wffTagUtil.f5(values[0]);var v33 = wffTagUtil.f17(
             v17, v25);var v92 = null;if(values[2].length == 0){
-            v92 = wffTagUtil.f18(values[3]);}else{
-            var v58 = wffTagUtil.f5(values[2]);var v73 = wffTagUtil.f23(values[1]);v92 = wffTagUtil.f16(v58,
+            v92 = wffTagUtil.f19(values[3]);}else{
+            var v58 = wffTagUtil.f5(values[2]);var v73 = wffTagUtil.f24(values[1]);v92 = wffTagUtil.f17(v58,
             v73);if(typeof v92 !== 'undefined'){
             var previousParent = v92.parentNode;if(typeof previousParent !== 'undefined'){
             previousParent.removeChild(v92);}
             }else{
-            v92 = wffTagUtil.f18(values[3]);}
+            v92 = wffTagUtil.f19(values[3]);}
             }
             v33.appendChild(v92);}
             }else if(taskValue == wffGlobal.taskValues.ADDED_ATTRIBUTES){
             for (var i = 1; i < v76.length; i++){
             var v84 = v76[i];if(v84.name[0] == wffGlobal.taskValues.MANY_TO_ONE){
-            var tagName = wffTagUtil.f5(v84.values[0]);var v98 = wffTagUtil
-            .f23(v84.values[1]);var v49 = wffTagUtil.f16(
-            tagName, v98);for (var j = 2; j < v84.values.length; j++){
+            var tagName = wffTagUtil.f5(v84.values[0]);var v99 = wffTagUtil
+            .f24(v84.values[1]);var v49 = wffTagUtil.f17(
+            tagName, v99);for (var j = 2; j < v84.values.length; j++){
             var v56 = wffTagUtil.f1(v84.values[j]);var v91 = v56[0];var v87 = v56[1];v49[v91] = v87;v49.setAttribute(v91, v87);}
             }
             }
             }else if(taskValue == wffGlobal.taskValues.REMOVED_ATTRIBUTES){
             for (var i = 1; i < v76.length; i++){
             var v84 = v76[i];if(v84.name[0] == wffGlobal.taskValues.MANY_TO_ONE){
-            var tagName = wffTagUtil.f5(v84.values[0]);var v98 = wffTagUtil
-            .f23(v84.values[1]);var v49 = wffTagUtil.f16(
-            tagName, v98);for (var j = 2; j < v84.values.length; j++){
+            var tagName = wffTagUtil.f5(v84.values[0]);var v99 = wffTagUtil
+            .f24(v84.values[1]);var v49 = wffTagUtil.f17(
+            tagName, v99);for (var j = 2; j < v84.values.length; j++){
             var v91 = wffTagUtil.getAttrNameFromCompressedBytes(v84.values[j]);v49.removeAttribute(v91);if(wffGlobal.NDXD_BLN_ATRBS.indexOf(v91) != -1){
             var prop = v49[v91];if(prop && prop === true){
             v49[v91] = false;}
@@ -382,37 +382,37 @@ public class WffJsFileTest {
             }
             }
             }else if(taskValue == wffGlobal.taskValues.ADDED_INNER_HTML){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil
-            .f23(v76[1].values[0]);var parentTag = wffTagUtil.f16(tagName,
-            v98);while (parentTag.firstChild){
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil
+            .f24(v76[1].values[0]);var parentTag = wffTagUtil.f17(tagName,
+            v99);while (parentTag.firstChild){
             parentTag.removeChild(parentTag.firstChild);}
             for (var i = 2; i < v76.length; i++){
-            var values = v76[i].values;var v89 = wffTagUtil.f18(v76[i].name);if(values.length == 1 && values[0].length == 1){
-            var existingTag = wffTagUtil.f16(
+            var values = v76[i].values;var v89 = wffTagUtil.f19(v76[i].name);if(values.length == 1 && values[0].length == 1){
+            var existingTag = wffTagUtil.f17(
             v89.nodeName, v89
             .getAttribute("data-wff-id"));if(existingTag){
             var v21 = existingTag.parentNode;v21.removeChild(existingTag);}
             }
             parentTag.appendChild(v89);}
             }else if(taskValue == wffGlobal.taskValues.INSERTED_BEFORE_TAG){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil.f23(v76[1].values[0]);var parentTag = wffTagUtil.f16(tagName, v98);var v50 = wffTagUtil.f5(v76[2].name);var v86;if(v50 === '#'){
-            var v20 = v76[2].values[0];v86 = wffTagUtil.f21(parentTag, v20);}else{
-            var v42 = wffTagUtil.f23(v76[2].values[0]);v86 = wffTagUtil.f16(v50,
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil.f24(v76[1].values[0]);var parentTag = wffTagUtil.f17(tagName, v99);var v50 = wffTagUtil.f5(v76[2].name);var v86;if(v50 === '#'){
+            var v20 = v76[2].values[0];v86 = wffTagUtil.f22(parentTag, v20);}else{
+            var v42 = wffTagUtil.f24(v76[2].values[0]);v86 = wffTagUtil.f17(v50,
             v42);}
             for (var i = 3; i < v76.length; i++){
-            var nm = v76[i].name;var values = v76[i].values;var v89 = wffTagUtil.f18(values[0]);if(nm.length == 1){
-            var existingTag = wffTagUtil.f16(
+            var nm = v76[i].name;var values = v76[i].values;var v89 = wffTagUtil.f19(values[0]);if(nm.length == 1){
+            var existingTag = wffTagUtil.f17(
             v89.nodeName, v89
             .getAttribute("data-wff-id"));var v21 = existingTag.parentNode;v21.removeChild(existingTag);}
             parentTag.insertBefore(v89, v86);}
             }else if(taskValue == wffGlobal.taskValues.INSERTED_AFTER_TAG){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil.f23(v76[1].values[0]);var parentTag = wffTagUtil.f16(tagName, v98);var v50 = wffTagUtil.f5(v76[2].name);var v86;if(v50 === '#'){
-            var v20 = v76[2].values[0];v86 = wffTagUtil.f21(parentTag, v20);}else{
-            var v42 = wffTagUtil.f23(v76[2].values[0]);v86 = wffTagUtil.f16(v50,
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil.f24(v76[1].values[0]);var parentTag = wffTagUtil.f17(tagName, v99);var v50 = wffTagUtil.f5(v76[2].name);var v86;if(v50 === '#'){
+            var v20 = v76[2].values[0];v86 = wffTagUtil.f22(parentTag, v20);}else{
+            var v42 = wffTagUtil.f24(v76[2].values[0]);v86 = wffTagUtil.f17(v50,
             v42);}
             var firstNd;for (var i = 3; i < v76.length; i++){
-            var nm = v76[i].name;var values = v76[i].values;var v89 = wffTagUtil.f18(values[0]);if(nm.length == 1){
-            var existingTag = wffTagUtil.f16(
+            var nm = v76[i].name;var values = v76[i].values;var v89 = wffTagUtil.f19(values[0]);if(nm.length == 1){
+            var existingTag = wffTagUtil.f17(
             v89.nodeName, v89
             .getAttribute("data-wff-id"));var v21 = existingTag.parentNode;v21.removeChild(existingTag);}
             parentTag.insertBefore(v89, v86);if(!firstNd){
@@ -421,32 +421,35 @@ public class WffJsFileTest {
             if(firstNd){
             parentTag.removeChild(v86);parentTag.insertBefore(v86, firstNd);}
             }else if(taskValue == wffGlobal.taskValues.REPLACED_WITH_TAGS){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil.f23(v76[1].values[0]);var parentTag = wffTagUtil.f16(tagName, v98);var v50 = wffTagUtil.f5(v76[2].name);var v86;if(v50 === '#'){
-            var v20 = v76[2].values[0];v86 = wffTagUtil.f21(parentTag, v20);}else{
-            var v42 = wffTagUtil.f23(v76[2].values[0]);v86 = wffTagUtil.f16(v50,
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil.f24(v76[1].values[0]);var parentTag = wffTagUtil.f17(tagName, v99);var v50 = wffTagUtil.f5(v76[2].name);var v86;if(v50 === '#'){
+            var v20 = v76[2].values[0];v86 = wffTagUtil.f22(parentTag, v20);}else{
+            var v42 = wffTagUtil.f24(v76[2].values[0]);v86 = wffTagUtil.f17(v50,
             v42);}
             for (var i = 3; i < v76.length; i++){
-            var nm = v76[i].name;var values = v76[i].values;var v89 = wffTagUtil.f18(values[0]);if(nm.length == 1){
-            var existingTag = wffTagUtil.f16(
+            var nm = v76[i].name;var values = v76[i].values;var v89 = wffTagUtil.f19(values[0]);if(nm.length == 1){
+            var existingTag = wffTagUtil.f17(
             v89.nodeName, v89
             .getAttribute("data-wff-id"));var v21 = existingTag.parentNode;v21.removeChild(existingTag);}
             parentTag.insertBefore(v89, v86);}
             parentTag.removeChild(v86);}else if(taskValue == wffGlobal.taskValues.RELOAD_BROWSER){
             location.reload(true);}else if(taskValue == wffGlobal.taskValues.RELOAD_BROWSER_FROM_CACHE){
             location.reload();}else if(taskValue == wffGlobal.taskValues.EXEC_JS){
-            var js = f30(v46.values[1]);var op = v46.values[2][0];if(op == 1){
+            var js = f31(v46.values[1]);var op = v46.values[2][0];if(op == 1){
             localStorage.setItem('WFF_EXEC_JS', JSON.stringify({ js: js, instanceId: wffGlobal.INSTANCE_ID }));localStorage.removeItem('WFF_EXEC_JS');}else{
             if(window.execScript){
             window.execScript(js);}else{
             eval(js);}
             }
             }else if(taskValue == wffGlobal.taskValues.SET_URI){
-            var jsObj = new JsObjectFromBMBytes(v46.values[1], true);jsObj.uriAfter = jsObj.ua;jsObj.uriBefore = jsObj.ub;jsObj.origin = jsObj.o;delete jsObj.ua;delete jsObj.ub;delete jsObj.o;if(jsObj.uriAfter && jsObj.uriAfter !== jsObj.uriBefore){
+            var jsObj = new JsObjectFromBMBytes(v46.values[1], true);jsObj.uriAfter = jsObj.ua;jsObj.uriBefore = jsObj.ub;jsObj.origin = jsObj.o;jsObj.replace = jsObj.r;delete jsObj.ua;delete jsObj.ub;delete jsObj.o;delete jsObj.r;if(jsObj.uriAfter && jsObj.uriAfter !== jsObj.uriBefore){
             if(jsObj.origin === 'S'){
             jsObj.origin = 'server';jsObj.initiator = 'serverCode';}
             var vnt = {};for (k in jsObj){
             vnt[k] = jsObj[k];}
-            history.pushState({}, document.title, jsObj.uriAfter);uriChangeQ.push(vnt);if(typeof wffGlobalListeners !== "undefined" && wffGlobalListeners.onSetURI && jsObj.origin === 'server'){
+            if(jsObj.replace){
+            history.replaceState({}, document.title, jsObj.uriAfter);}else{
+            history.pushState({}, document.title, jsObj.uriAfter);}
+            uriChangeQ.push(vnt);if(typeof wffGlobalListeners !== "undefined" && wffGlobalListeners.onSetURI && jsObj.origin === 'server'){
             try {
             wffGlobalListeners.onSetURI(vnt);} catch (e){
             wffLog("wffGlobalListeners.onSetURI threw exception when browserPage.setURI is called", e);}
@@ -468,16 +471,16 @@ public class WffJsFileTest {
             wffLog(e);}
             }
             if(wt >= lstWT){
-            var id = wffBMUtil.f14(jsObj.id);if(wt > lstWT || (wt == lstWT && id > lstId)){
+            var id = wffBMUtil.f15(jsObj.id);if(wt > lstWT || (wt == lstWT && id > lstId)){
             var itemVal = JSON.stringify({ v: jsObj.v, wt: jsObj.wt, id: id });localStorage.setItem(jsObj.k + '_wff_data', itemVal);}
             }
             if(jsObj.cb){
-            var v46 = wffTaskUtil.f34(
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             taskValue);var v84 = {
             'name': jsObj.id,
             'values': []
-            };var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);}
+            };var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);}
             }
             }else if(taskValue == wffGlobal.taskValues.GET_LS_ITEM){
             var jsObj = new JsObjectFromBMBytes(v46.values[1], true);if(typeof localStorage !== "undefined" && jsObj.id && jsObj.k){
@@ -488,14 +491,14 @@ public class WffJsFileTest {
             }
             if(!itemObj || !itemObj.wt){
             itemObj = {};}
-            var v46 = wffTaskUtil.f34(
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             taskValue);var v84 = {
             'name': jsObj.id,
             'values': []
             };if(itemObj.wt){
             v84.values = [encoder.encode(itemObj.v), encoder.encode(itemObj.wt)];}
-            var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);}
+            var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);}
             }else if(taskValue == wffGlobal.taskValues.REMOVE_LS_ITEM || taskValue == wffGlobal.taskValues.REMOVE_AND_GET_LS_ITEM){
             var jsObj = new JsObjectFromBMBytes(v46.values[1], true);if(typeof localStorage !== "undefined" && jsObj.k && jsObj.wt && jsObj.id){
             var itemJSON = localStorage.getItem(jsObj.k + '_wff_data');var itemObj;if(itemJSON){
@@ -506,19 +509,19 @@ public class WffJsFileTest {
             if(!itemObj || !itemObj.wt || !itemObj.id){
             itemObj = {};}else{
             var jsObjWT = parseInt(jsObj.wt);var itemObjWT = parseInt(itemObj.wt);if(jsObjWT >= itemObjWT){
-            var id = wffBMUtil.f14(jsObj.id);if(jsObjWT > itemObjWT || (jsObjWT == itemObjWT && id > itemObj.id)){
+            var id = wffBMUtil.f15(jsObj.id);if(jsObjWT > itemObjWT || (jsObjWT == itemObjWT && id > itemObj.id)){
             localStorage.removeItem(jsObj.k + '_wff_data');}
             }
             }
             if(jsObj.cb){
-            var v46 = wffTaskUtil.f34(
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             taskValue);var v84 = {
             'name': jsObj.id,
             'values': []
             };if(taskValue == wffGlobal.taskValues.REMOVE_AND_GET_LS_ITEM && itemObj.wt){
             v84.values = [encoder.encode(itemObj.v), encoder.encode(itemObj.wt)];}
-            var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);}
+            var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);}
             }
             }else if(taskValue == wffGlobal.taskValues.CLEAR_LS){
             var jsObj = new JsObjectFromBMBytes(v46.values[1], true);if(typeof localStorage !== "undefined" && jsObj.wt && jsObj.tp && jsObj.id){
@@ -528,7 +531,7 @@ public class WffJsFileTest {
             try {
             var itemObj = JSON.parse(localStorage.getItem(k));if(itemObj && itemObj.wt && itemObj.id){
             var jsObjWT = parseInt(jsObj.wt);var itemObjWT = parseInt(itemObj.wt);if(jsObjWT >= itemObjWT){
-            var id = wffBMUtil.f14(jsObj.id);if(jsObjWT > itemObjWT || (jsObjWT == itemObjWT && id > itemObj.id)){
+            var id = wffBMUtil.f15(jsObj.id);if(jsObjWT > itemObjWT || (jsObjWT == itemObjWT && id > itemObj.id)){
             if(k.endsWith('_wff_token')){
             itemObj.removed = true;itemObj.id = id;itemObj.wt = jsObj.wt;itemObj.nid = wffGlobal.NODE_ID;localStorage.setItem(k, JSON.stringify(itemObj));}
             localStorage.removeItem(k);}
@@ -539,12 +542,12 @@ public class WffJsFileTest {
             }
             }
             if(jsObj.cb){
-            var v46 = wffTaskUtil.f34(
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             taskValue);var v84 = {
             'name': jsObj.id,
             'values': []
-            };var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);}
+            };var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);}
             }
             }else if(taskValue == wffGlobal.taskValues.SET_LS_TOKEN){
             var jsObj = new JsObjectFromBMBytes(v46.values[1], true);if(typeof localStorage !== "undefined" && jsObj.k && jsObj.wt && jsObj.id){
@@ -554,7 +557,7 @@ public class WffJsFileTest {
             wffLog(e);}
             }
             if(wt >= lstWT){
-            var id = wffBMUtil.f14(jsObj.id);if(wt > lstWT || (wt == lstWT && id > lstId)){
+            var id = wffBMUtil.f15(jsObj.id);if(wt > lstWT || (wt == lstWT && id > lstId)){
             var itemVal = JSON.stringify({ v: jsObj.v, wt: jsObj.wt, nid: wffGlobal.NODE_ID, id: id });localStorage.setItem(tknNm, itemVal);}
             }
             }
@@ -567,75 +570,75 @@ public class WffJsFileTest {
             }
             if(itemObj && itemObj.wt && itemObj.id){
             var jsObjWT = parseInt(jsObj.wt);var itemObjWT = parseInt(itemObj.wt);if(jsObjWT >= itemObjWT){
-            var id = wffBMUtil.f14(jsObj.id);if(jsObjWT >= itemObjWT || (jsObjWT == itemObjWT && id > itemObj.id)){
+            var id = wffBMUtil.f15(jsObj.id);if(jsObjWT >= itemObjWT || (jsObjWT == itemObjWT && id > itemObj.id)){
             itemObj.removed = true;itemObj.id = id;itemObj.wt = jsObj.wt;itemObj.nid = wffGlobal.NODE_ID;localStorage.setItem(tknNm, JSON.stringify(itemObj));localStorage.removeItem(tknNm);}
             }
             }
             }
             }else if(taskValue == wffGlobal.taskValues.COPY_INNER_TEXT_TO_VALUE){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil
-            .f23(v76[1].values[0]);var parentTag = wffTagUtil.f16(tagName,
-            v98);var d = document.createElement('div');d.innerHTML = parentTag.outerHTML;parentTag.value = d.childNodes[0].innerText;}else if(taskValue == wffGlobal.taskValues.SET_BM_OBJ_ON_TAG
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil
+            .f24(v76[1].values[0]);var parentTag = wffTagUtil.f17(tagName,
+            v99);var d = document.createElement('div');d.innerHTML = parentTag.outerHTML;parentTag.value = d.childNodes[0].innerText;}else if(taskValue == wffGlobal.taskValues.SET_BM_OBJ_ON_TAG
             || taskValue == wffGlobal.taskValues.SET_BM_ARR_ON_TAG){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil
-            .f23(v76[1].values[0]);var tag = wffTagUtil.f16(tagName, v98);var ky = f30(v76[1].values[1]);var v38 = v76[1].values[2];var jsObjOrArr;if(taskValue == wffGlobal.taskValues.SET_BM_OBJ_ON_TAG){
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil
+            .f24(v76[1].values[0]);var tag = wffTagUtil.f17(tagName, v99);var ky = f31(v76[1].values[1]);var v38 = v76[1].values[2];var jsObjOrArr;if(taskValue == wffGlobal.taskValues.SET_BM_OBJ_ON_TAG){
             jsObjOrArr = new JsObjectFromBMBytes(v38, true);}else{
             jsObjOrArr = new JsArrayFromBMBytes(v38, true);}
             var wffObjects = tag['wffObjects'];if(typeof wffObjects === 'undefined'){
             wffObjects = {};tag['wffObjects'] = wffObjects;}
             wffObjects[ky] = jsObjOrArr;}else if(taskValue == wffGlobal.taskValues.DEL_BM_OBJ_OR_ARR_FROM_TAG){
-            var tagName = wffTagUtil.f5(v76[1].name);var v98 = wffTagUtil
-            .f23(v76[1].values[0]);var tag = wffTagUtil.f16(tagName, v98);var ky = f30(v76[1].values[1]);var wffObjects = tag['wffObjects'];if(typeof wffObjects !== 'undefined'){
+            var tagName = wffTagUtil.f5(v76[1].name);var v99 = wffTagUtil
+            .f24(v76[1].values[0]);var tag = wffTagUtil.f17(tagName, v99);var ky = f31(v76[1].values[1]);var wffObjects = tag['wffObjects'];if(typeof wffObjects !== 'undefined'){
             delete wffObjects[ky];}
             }
-            return true;};this.f42 = function(v79){
-            var v76 = wffBMUtil.f9(v79);var v46 = v76[0];if(v46.name[0] == wffGlobal.taskValues.TASK){
-            f44(v76);}else if(v46.name[0] == wffGlobal.taskValues.TASK_OF_TASKS){
+            return true;};this.f43 = function(v79){
+            var v76 = wffBMUtil.f10(v79);var v46 = v76[0];if(v46.name[0] == wffGlobal.taskValues.TASK){
+            f45(v76);}else if(v46.name[0] == wffGlobal.taskValues.TASK_OF_TASKS){
             var tasksBM = v46.values;for (var i = 0; i < tasksBM.length; i++){
-            var v45 = wffBMUtil.f9(tasksBM[i]);f44(v45);}
+            var v45 = wffBMUtil.f10(tasksBM[i]);f45(v45);}
             }else{
             return false;}
-            return true;};this.f29 = function(v79){
-            var v84 = wffBMUtil.f9(v79)[1];};};wffGlobal.frz(wffClientCRUDUtil, false);
+            return true;};this.f30 = function(v79){
+            var v84 = wffBMUtil.f10(v79)[1];};};wffGlobal.frz(wffClientCRUDUtil, false);
             var wffTaskUtil = new function (){
-            var encoder = wffGlobal.encoder;this.f34 = function(v93, valueByte){
+            var encoder = wffGlobal.encoder;this.f35 = function(v93, valueByte){
             var v46 = {
             'name' : [v93],
             'values' : [ [valueByte] ]
             };return v46;};};var wffServerMethods = new function (){
-            var encoder = wffGlobal.encoder;var f24 = function(v70){
+            var encoder = wffGlobal.encoder;var f25 = function(v70){
             var v88 = [];if(typeof v70 === 'string'){
             var ndx = wffGlobal.NDXD_VNT_ATRBS.indexOf(v70);if(ndx != -1){
-            var ndxByts = wffBMUtil.f15(ndx);v88.push(0);for (var i = 0; i < ndxByts.length; i++){
+            var ndxByts = wffBMUtil.f16(ndx);v88.push(0);for (var i = 0; i < ndxByts.length; i++){
             v88.push(ndxByts[i]);}
             }else{
             v88 = encoder.encode(v70);}
             }else{
-            var ndxByts = wffBMUtil.f15(v70);v88.push(0);for (var i = 0; i < ndxByts.length; i++){
+            var ndxByts = wffBMUtil.f16(v70);v88.push(0);for (var i = 0; i < ndxByts.length; i++){
             v88.push(ndxByts[i]);}
             }
-            return v88;};var f41 = function(event, tag, v70, prvntDflt){
+            return v88;};var f42 = function(event, tag, v70, prvntDflt){
             if(prvntDflt){
             event.preventDefault();}
-            var v46 = wffTaskUtil.f34(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f24(v70);var v84 = {'name':wffTagUtil.f25(tag), 'values':[v88]};var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};this.b = function(event, tag, v70){
-            f41(event, tag, v70, true);};var invokeAsync = function(event, tag, v70){
-            f41(event, tag, v70, false);};this.a = invokeAsync;var f22 = function(event, tag, v70, preFun, prvntDflt){
+            var v46 = wffTaskUtil.f35(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f25(v70);var v84 = {'name':wffTagUtil.f26(tag), 'values':[v88]};var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};this.b = function(event, tag, v70){
+            f42(event, tag, v70, true);};var invokeAsync = function(event, tag, v70){
+            f42(event, tag, v70, false);};this.a = invokeAsync;var f23 = function(event, tag, v70, preFun, prvntDflt){
             if(prvntDflt){
             event.preventDefault();}
             var invoked = false;var actionPerform = function(){
-            invoked = true;var v46 = wffTaskUtil.f34(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f24(v70);var v84 = {'name':wffTagUtil.f25(tag), 'values':[v88]};var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};var action = new function(){
+            invoked = true;var v46 = wffTaskUtil.f35(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f25(v70);var v84 = {'name':wffTagUtil.f26(tag), 'values':[v88]};var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};var action = new function(){
             this.perform = function(){
             actionPerform();};};if(preFun(event, tag, action)){
             if(!invoked){
             actionPerform();}
             }
             };this.f = function(event, tag, v70, preFun){
-            f22(event, tag, v70, preFun, true);};var invokeAsyncWithPreFun = function(event, tag, v70, preFun){
-            f22(event, tag, v70, preFun, false);};this.e = invokeAsyncWithPreFun;var f6 = function(event, tag, v70, preFun, filterFun, prvntDflt){
+            f23(event, tag, v70, preFun, true);};var invokeAsyncWithPreFun = function(event, tag, v70, preFun){
+            f23(event, tag, v70, preFun, false);};this.e = invokeAsyncWithPreFun;var f6 = function(event, tag, v70, preFun, filterFun, prvntDflt){
             if(prvntDflt){
             event.preventDefault();}
             var invoked = false;var actionPerform = function(){
-            invoked = true;var v46 = wffTaskUtil.f34(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f24(v70);var jsObject = filterFun(event, tag);var v32 = new WffBMObject(jsObject);var v94 = v32.getBMBytes();var v84 = {'name':wffTagUtil.f25(tag), 'values':[v88, v94]};var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};var action = new function(){
+            invoked = true;var v46 = wffTaskUtil.f35(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f25(v70);var jsObject = filterFun(event, tag);var v32 = new WffBMObject(jsObject);var v94 = v32.getBMBytes();var v84 = {'name':wffTagUtil.f26(tag), 'values':[v88, v94]};var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};var action = new function(){
             this.perform = function(){
             actionPerform();};};if(preFun(event, tag, action)){
             if(!invoked){
@@ -643,19 +646,19 @@ public class WffJsFileTest {
             }
             };this.h = function(event, tag, v70, preFun, filterFun){
             f6(event, tag, v70, preFun, filterFun, true);};var invokeAsyncWithPreFilterFun = function(event, tag, v70, preFun, filterFun){
-            f6(event, tag, v70, preFun, filterFun, false);};this.g = invokeAsyncWithPreFilterFun;var f10 = function(event, tag, v70, filterFun, prvntDflt){
+            f6(event, tag, v70, preFun, filterFun, false);};this.g = invokeAsyncWithPreFilterFun;var f11 = function(event, tag, v70, filterFun, prvntDflt){
             if(prvntDflt){
             event.preventDefault();}
-            var v46 = wffTaskUtil.f34(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f24(v70);var jsObject = filterFun(event, tag);var v32 = new WffBMObject(jsObject);var v94 = v32.getBMBytes();var v84 = {'name':wffTagUtil.f25(tag), 'values':[v88, v94]};var v76 = [v46, v84];var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};this.d = function(event, tag, v70, filterFun){
-            f10(event, tag, v70, filterFun, true);};var invokeAsyncWithFilterFun = function(event, tag, v70, filterFun){
-            f10(event, tag, v70, filterFun, false);};this.c = invokeAsyncWithFilterFun;};var wffSM = wffServerMethods;wffGlobal.frz(wffTaskUtil, false);wffGlobal.frz(wffSM, false);
+            var v46 = wffTaskUtil.f35(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f25(v70);var jsObject = filterFun(event, tag);var v32 = new WffBMObject(jsObject);var v94 = v32.getBMBytes();var v84 = {'name':wffTagUtil.f26(tag), 'values':[v88, v94]};var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};this.d = function(event, tag, v70, filterFun){
+            f11(event, tag, v70, filterFun, true);};var invokeAsyncWithFilterFun = function(event, tag, v70, filterFun){
+            f11(event, tag, v70, filterFun, false);};this.c = invokeAsyncWithFilterFun;};var wffSM = wffServerMethods;wffGlobal.frz(wffTaskUtil, false);wffGlobal.frz(wffSM, false);
             var wffClientMethods = new function(){
-            var f30 = function(utf8Bytes){
+            var f31 = function(utf8Bytes){
             return wffGlobal.decoder.decode(new Uint8Array(utf8Bytes));};this.exePostFun = function(v79){
-            var v76 = wffBMUtil.f9(v79);var v46 = v76[0];var taskValue = v46.values[0][0];if(v46.name[0] != wffGlobal.taskValues.TASK){
+            var v76 = wffBMUtil.f10(v79);var v46 = v76[0];var taskValue = v46.values[0][0];if(v46.name[0] != wffGlobal.taskValues.TASK){
             return false;}
             if(taskValue == wffGlobal.taskValues.INVOKE_POST_FUNCTION){
-            var funString = f30(v76[1].name);var values = v76[1].values;var jsObject = null;if(values.length > 0){
+            var funString = f31(v76[1].name);var values = v76[1].values;var jsObject = null;if(values.length > 0){
             var value = values[0];if(value.length > 0){
             var bmObjBytes = v76[1].values[0];jsObject = new JsObjectFromBMBytes(bmObjBytes, true);}
             }
@@ -664,14 +667,14 @@ public class WffJsFileTest {
             + "})");}else{
             func = eval("(function(jsObject){" + funString + "})");}
             func(jsObject);}else if(taskValue == wffGlobal.taskValues.INVOKE_CALLBACK_FUNCTION){
-            var funKey = f30(v76[1].name);var cbFun = wffAsync.v27[funKey];var values = v76[1].values;var jsObject = null;if(values.length > 0){
+            var funKey = f31(v76[1].name);var cbFun = wffAsync.v27[funKey];var values = v76[1].values;var jsObject = null;if(values.length > 0){
             var value = values[0];if(value.length > 0){
             var bmObjBytes = v76[1].values[0];jsObject = new JsObjectFromBMBytes(bmObjBytes, true);}
             }
             cbFun(jsObject);delete wffAsync.v27[funKey];}else{
             return false;}
             return true;};};wffGlobal.frz(wffClientMethods, false);
-            var f35 = function(valueType){
+            var f36 = function(valueType){
             if(valueType === '[object String]'){
             return 0;}else if(valueType === '[object Number]'){
             return 1;}else if(valueType === '[object Undefined]'){
@@ -693,7 +696,7 @@ public class WffJsFileTest {
             };v76.push(typeNameValue);}
             if(jsArray.length > 0){
             var arrayValType;for (var i = 0; i < jsArray.length; i++){
-            arrayValType = f35(Object.prototype.toString
+            arrayValType = f36(Object.prototype.toString
             .call(jsArray[i]));if(arrayValType != 2 && arrayValType != 3){
             break;}
             }
@@ -708,7 +711,7 @@ public class WffJsFileTest {
             }else if(arrayValType == 1){
             for (var i = 0; i < jsArray.length; i++){
             if(arrayValType != 2 && arrayValType != 3){
-            values.push(wffBMUtil.f32(jsArray[i]));}else{
+            values.push(wffBMUtil.f33(jsArray[i]));}else{
             values.push([]);}
             }
             }  else if(arrayValType == 2
@@ -748,7 +751,7 @@ public class WffJsFileTest {
             }else{
             values.push([]);}
             }
-            return wffBMUtil.f13(v76);};this.getBMBytes = function getBMBytes(){
+            return wffBMUtil.f14(v76);};this.getBMBytes = function getBMBytes(){
             return getWffBMArray(this.jsArray, this.outer);};return this;};var WffBMByteArray = function(int8Array, outer){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;this.jsArray = int8Array;this.outer = outer;var getWffBMByteArray = function(int8Array, outer){
             var v76 = [];if(typeof outer === 'undefined' || outer){
@@ -758,7 +761,7 @@ public class WffJsFileTest {
             };v76.push(typeNameValue);}
             var arrayValType = 10;var v84 = {
             name : [ arrayValType ]
-            };v76.push(v84);v84.values = [ int8Array ];return wffBMUtil.f13(v76);};this.getBMBytes = function getBMBytes(){
+            };v76.push(v84);v84.values = [ int8Array ];return wffBMUtil.f14(v76);};this.getBMBytes = function getBMBytes(){
             return getWffBMByteArray(this.jsArray, this.outer);};return this;};var WffBMObject = function(jsObject, outer){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;this.jsObject = jsObject;this.outer = outer;var getWffBMObject = function(jsObj, outer){
             var jsObjType = Object.prototype.toString.call(jsObj);var v76 = [];if(typeof outer === 'undefined' || outer){
@@ -767,10 +770,10 @@ public class WffJsFileTest {
             values : []
             };v76.push(typeNameValue);}
             for ( var k in jsObj){
-            var value = jsObj[k];var valType = f35(Object.prototype.toString
+            var value = jsObj[k];var valType = f36(Object.prototype.toString
             .call(value));var v84 = {};v84.name = encoder.encode(k);var values = [ [ valType ] ];v84.values = values;var typeByte = [ valType ];if(valType == 0){
             values.push(encoder.encode(value));}else if(valType == 1){
-            values.push(wffBMUtil.f32(value));}else if(valType == 2){
+            values.push(wffBMUtil.f33(value));}else if(valType == 2){
             values.push([]);}else if(valType == 3){
             values.push([]);}else if(valType == 4){
             if(value){
@@ -786,36 +789,36 @@ public class WffJsFileTest {
             values.push(new WffBMByteArray(value, false).getBMBytes());}else{
             values.push([]);}
             v76.push(v84);}
-            return wffBMUtil.f13(v76);};this.getBMBytes = function getBMBytes(){
+            return wffBMUtil.f14(v76);};this.getBMBytes = function getBMBytes(){
             return getWffBMObject(this.jsObject, this.outer);};};var JsObjectFromBMBytes = function(v79, outer){
-            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f30 = function(utf8Bytes){
-            return wffGlobal.decoder.decode(new Uint8Array(utf8Bytes));};var v76 = wffBMUtil.f9(v79);var i = 0;if(typeof outer === 'undefined' || outer){
+            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f31 = function(utf8Bytes){
+            return wffGlobal.decoder.decode(new Uint8Array(utf8Bytes));};var v76 = wffBMUtil.f10(v79);var i = 0;if(typeof outer === 'undefined' || outer){
             i = 1;}
             for (; i < v76.length; i++){
-            var v84 = v76[i];var name = f30(v84.name);var values = v84.values;if(values[0] == 0){
-            this[name] = f30(values[1]);}else if(values[0] == 1){
+            var v84 = v76[i];var name = f31(v84.name);var values = v84.values;if(values[0] == 0){
+            this[name] = f31(values[1]);}else if(values[0] == 1){
             this[name] = wffBMUtil.f8(values[1]);}else if(values[0] == 2){
             this[name] = undefined;}else if(values[0] == 3){
             this[name] = null;}else if(values[0] == 4){
             this[name] = values[1] == 1 ? true : false;}else if(values[0] == 5){
             this[name] = new JsObjectFromBMBytes(values[1], false);}else if(values[0] == 6){
             this[name] = new JsArrayFromBMBytes(values[1], false);}else if(values[0] == 7){
-            this[name] = new RegExp(f30(values[1]));}else if(values[0] == 8){
+            this[name] = new RegExp(f31(values[1]));}else if(values[0] == 8){
             if(window.execScript){
             this[name] = window.execScript("("
-            + f30(values[1]) + ")");}else{
-            this[name] = eval("(" + f30(values[1]) + ")");}
+            + f31(values[1]) + ")");}else{
+            this[name] = eval("(" + f31(values[1]) + ")");}
             }else if(values[0] == 9){
             this[name] = new JsArrayFromBMBytes(values[1], false);}else if(values[0] == 10){
             this[name] = new Int8Array(values[1]);}
             }
             return this;};var JsArrayFromBMBytes = function(v79, outer){
-            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f30 = function(utf8Bytes){
-            return decoder.decode(new Uint8Array(utf8Bytes));};var v76 = wffBMUtil.f9(v79);var i = 0;if(typeof outer === 'undefined' || outer){
+            var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f31 = function(utf8Bytes){
+            return decoder.decode(new Uint8Array(utf8Bytes));};var v76 = wffBMUtil.f10(v79);var i = 0;if(typeof outer === 'undefined' || outer){
             i = 1;}
             var v84 = v76[i];var dataType = v84.name[0];var values = v84.values;var jsArray = [];if(dataType == 0){
             for (var j = 0; j < values.length; j++){
-            jsArray.push(f30(values[j]));}
+            jsArray.push(f31(values[j]));}
             }else if(dataType == 1){
             for (var j = 0; j < values.length; j++){
             jsArray.push(wffBMUtil.f8(values[j]));}
@@ -836,10 +839,10 @@ public class WffJsFileTest {
             jsArray.push(new JsArrayFromBMBytes(values[j], false));}
             }else if(dataType == 7){
             for (var j = 0; j < values.length; j++){
-            jsArray.push(new RegExp(f30(values[j])));}
+            jsArray.push(new RegExp(f31(values[j])));}
             }else if(dataType == 8){
             for (var j = 0; j < values.length; j++){
-            var fun = f30(values[j]);var ary;if(window.execScript){
+            var fun = f31(values[j]);var ary;if(window.execScript){
             ary = [ window.execScript("(" + fun + ")") ];}else{
             ary = [ eval("(" + fun + ")") ];}
             jsArray.push(ary[0]);}
@@ -865,7 +868,7 @@ public class WffJsFileTest {
             v47 = wffAsync.generateUUID();wffAsync.v27[v47] = callback;}else if(typeof callback === "undefined"){
             }else{
             throw "invoke function takes function argument";}
-            var v46 = wffTaskUtil.f34(
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             wffGlobal.taskValues.INVOKE_CUSTOM_SERVER_METHOD);var v36 = encoder.encode(v81);var values = [];if(typeof jsObject !== "undefined"){
             if(typeof jsObject === "object"){
@@ -880,31 +883,38 @@ public class WffJsFileTest {
             'name' : encoder.encode(v47),
             'values' : []
             };v76.push(v15);}
-            var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};return this;};var setServerURIWithCallback = function(uri, callback, initiator){
-            var v46 = wffTaskUtil.f34(
+            var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};return this;};var f9 = function(uri, callback, initiator, rplc){
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             wffGlobal.taskValues.CLIENT_PATHNAME_CHANGED);var v84 = {
             'name': encoder.encode(uri),
             'values': []
-            };if(typeof initiator !== "undefined" && initiator >= 0 && initiator < wffGlobal.uriEventInitiator.size){
-            v84.values.push([initiator]);}else{
-            v84.values.push([wffGlobal.uriEventInitiator.CLIENT_CODE]);}
+            };var v97 = rplc ? 1 : 0;if(typeof initiator !== "undefined" && initiator >= 0 && initiator < wffGlobal.uriEventInitiator.size){
+            v84.values.push([initiator, v97]);}else{
+            v84.values.push([wffGlobal.uriEventInitiator.CLIENT_CODE, v97]);}
             var v76 = [v46, v84];if(callback){
             var v47 = wffAsync.generateUUID();wffAsync.v27[v47] = callback;var v15 = {
             'name': encoder.encode(v47),
             'values': []
             };v76.push(v15);}
-            var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};this.setServerURIWithCallback = setServerURIWithCallback;this.setServerURI = function(uri){ setServerURIWithCallback(uri, undefined, wffGlobal.uriEventInitiator.CLIENT_CODE); };var throwInvalidSetURIArgException = function(){
+            var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};this.setServerURIWithCallback = function(uri, callback, initiator){f9(uri, callback, initiator, false);};this.setServerURI = function(uri){ f9(uri, undefined, wffGlobal.uriEventInitiator.CLIENT_CODE, false); };var throwInvalidSetURIArgException = function(){
             throw "Invalid argument found in setURI function call. " +
-            "Eg: wffAsync.setURI('/sampleuri', function(e){}, function(e){});, " +
-            "wffAsync.setURI('/sampleuri', function(e){}); or " +
-            "wffAsync.setURI('/sampleuri');";};this.setURI = function(uri, onSetURI, afterSetURI){
-            if(typeof onSetURI !== "undefined" && typeof onSetURI !== "function"){
+            "Eg: wffAsync.setURI('/sampleuri', function(e){}, function(e){}, false);, " +
+            "wffAsync.setURI('/sampleuri', function(e){}, function(e){});, " +
+            "wffAsync.setURI('/sampleuri', function(e){});, " +
+            "wffAsync.setURI('/sampleuri'); or " +
+            "wffAsync.setURI('/sampleuri', null, null, false);";};this.setURI = function(uri, onSetURI, afterSetURI, replace){
+            if(typeof onSetURI !== "undefined" && onSetURI !== null && typeof onSetURI !== "function"){
             throwInvalidSetURIArgException();}
-            if(typeof afterSetURI !== "undefined" && typeof afterSetURI !== "function"){
+            if(typeof afterSetURI !== "undefined" && afterSetURI !== null && typeof afterSetURI !== "function"){
             throwInvalidSetURIArgException();}
-            var uriBefore = window.location.pathname;history.pushState({}, document.title, uri);var uriAfter = window.location.pathname;if(uriBefore !== uriAfter){
-            var wffEvent = { uriBefore: uriBefore, uriAfter: uriAfter, origin: "client", initiator: 'clientCode' };var callbackWrapper = afterSetURI;if(typeof wffGlobalListeners !== "undefined"){
+            if(typeof replace !== "undefined" && replace !== null && typeof replace !== "boolean"){
+            throwInvalidSetURIArgException();}
+            var uriBefore = window.location.pathname;if(replace){
+            history.replaceState({}, document.title, uri);}else{
+            history.pushState({}, document.title, uri);}
+            var uriAfter = window.location.pathname;if(uriBefore !== uriAfter){
+            var wffEvent = { uriBefore: uriBefore, uriAfter: uriAfter, origin: "client", initiator: 'clientCode', replace: replace ? true : false };var callbackWrapper = afterSetURI;if(typeof wffGlobalListeners !== "undefined"){
             if(wffGlobalListeners.onSetURI){
             try {
             wffGlobalListeners.onSetURI(wffEvent);} catch (e){
@@ -927,24 +937,24 @@ public class WffJsFileTest {
             onSetURI(wffEvent);}
             } catch (e){
             wffLog("The second argument threw exception when wffAsync.setURI is called", e);}
-            setServerURIWithCallback(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.CLIENT_CODE);}
+            f9(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.CLIENT_CODE, replace);}
             };};wffGlobal.frz(window.wffAsync, false);
             var wffBMClientEvents = new function(){
-            window.v1 = false;var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f27 = function(wffInstanceId){
-            var v76 = [];var v23 = encoder.encode(wffInstanceId);var tnv = wffTaskUtil.f34(
+            window.v1 = false;var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f28 = function(wffInstanceId){
+            var v76 = [];var v23 = encoder.encode(wffInstanceId);var tnv = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             wffGlobal.taskValues.REMOVE_BROWSER_PAGE);v76.push(tnv);var v84 = {
             'name' : v23,
             'values' : []
-            };v76.push(v84);var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};this.f27 = f27;this.f20 = function(){
+            };v76.push(v84);var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};this.f28 = f28;this.f21 = function(){
             if(!wffGlobal.REMOVE_PREV_BP_ON_INITTAB ||
             window.v1){
             return;}
             window.v1 = true;var wffInstanceId = sessionStorage.getItem('WFF_INSTANCE_ID');if(typeof wffInstanceId !== "undefined"
             && wffInstanceId !== wffGlobal.INSTANCE_ID){
-            f27(wffInstanceId);}
-            sessionStorage.setItem('WFF_INSTANCE_ID', wffGlobal.INSTANCE_ID);};this.f37 = function(){
-            var v76 = [];var tnv = wffTaskUtil.f34(
+            f28(wffInstanceId);}
+            sessionStorage.setItem('WFF_INSTANCE_ID', wffGlobal.INSTANCE_ID);};this.f38 = function(){
+            var v76 = [];var tnv = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             wffGlobal.taskValues.INITIAL_WS_OPEN);v76.push(tnv);if(window.location && window.location.pathname){
             var pthNV = {
@@ -965,7 +975,7 @@ public class WffJsFileTest {
             'values': [bmBts]
             };v76.push(nv);}
             }
-            var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);};};wffGlobal.frz(wffBMClientEvents, false);
+            var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};};wffGlobal.frz(wffBMClientEvents, false);
             var wffWS = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var prevIntvl = null;var webSocket = null;var inDataQ = [];var sendQData = null;this.openSocket = function(wsUrl){
             if(webSocket !== null
@@ -987,20 +997,20 @@ public class WffJsFileTest {
             try {
             if(prevIntvl !== null){
             clearInterval(prevIntvl);prevIntvl = null;}
-            wffBMClientEvents.f20();if(sendQData !== null){
+            wffBMClientEvents.f21();if(sendQData !== null){
             sendQData();}
             if(typeof event.data === 'undefined'){
             return;}
             var binary = new Int8Array(event.data);if(binary.length < 4){
             return;}
-            wffClientCRUDUtil.f42(binary);}catch(e){
+            wffClientCRUDUtil.f43(binary);}catch(e){
             wffLog(e);}
             };webSocket.onmessage = function(event){
             try {
             var binary = new Int8Array(event.data);if(binary.length < 4){
             return;}
             var executed = wffClientMethods.exePostFun(binary);if(!executed){
-            wffClientCRUDUtil.f42(binary);}
+            wffClientCRUDUtil.f43(binary);}
             }catch(e){
             wffLog(e);}
             };webSocket.onclose = function(event){
@@ -1031,19 +1041,19 @@ public class WffJsFileTest {
             return -1;};};wffGlobal.frz(wffWS, false);
             document.addEventListener("DOMContentLoaded",
             function(event){
-            var encoder = wffGlobal.encoder;if(typeof window.f37Invoked === 'undefined'){
-            window.f37Invoked = true;wffBMClientEvents.f37();}
-            wffWS.openSocket(wffGlobal.WS_URL);window.v30 = false;var f36 = function(){
+            var encoder = wffGlobal.encoder;if(typeof window.f38Invoked === 'undefined'){
+            window.f38Invoked = true;wffBMClientEvents.f38();}
+            wffWS.openSocket(wffGlobal.WS_URL);window.v30 = false;var f37 = function(){
             if(!window.v30){
-            wffBMClientEvents.f27(sessionStorage.getItem('WFF_INSTANCE_ID'));}
-            window.v30 = true;};var f11 = function (eventName){
+            wffBMClientEvents.f28(sessionStorage.getItem('WFF_INSTANCE_ID'));}
+            window.v30 = true;};var f12 = function (eventName){
             var el = window;eventName = 'on' + eventName;var isSupported = (eventName in el);if(!isSupported && typeof InstallTrigger !== 'undefined'){
             el.setAttribute(eventName, 'return;');isSupported = typeof el[eventName] == 'function';}
-            el = null;return isSupported;};if(f11('beforeunload')){
-            window.addEventListener("beforeunload", f36, false);}
-            if(f11('unload')){
-            window.addEventListener("unload", f36, false);}
-            if(f11('popstate')){
+            el = null;return isSupported;};if(f12('beforeunload')){
+            window.addEventListener("beforeunload", f37, false);}
+            if(f12('unload')){
+            window.addEventListener("unload", f37, false);}
+            if(f12('popstate')){
             window.addEventListener('popstate', function(event){
             var uriAfter = window.location.pathname;if(typeof wffGlobalListeners !== "undefined"){
             var wffEvent = { uriAfter: uriAfter, origin: "client", initiator: 'browser' };if(wffGlobalListeners.onSetURI){
@@ -1060,7 +1070,7 @@ public class WffJsFileTest {
             wffAsync.setServerURIWithCallback(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.BROWSER);}else{
             wffAsync.setServerURIWithCallback(uriAfter, undefined, wffGlobal.uriEventInitiator.BROWSER);}
             });}
-            if(f11('storage') && typeof localStorage !== "undefined"){
+            if(f12('storage') && typeof localStorage !== "undefined"){
             window.addEventListener('storage', function(event){
             if(event && event.key && event.newValue){
             var ndx = event.key.lastIndexOf('_wff_token')
@@ -1069,20 +1079,20 @@ public class WffJsFileTest {
             itemObj = JSON.parse(event.newValue);} catch (e){
             wffLog(e);}
             if(itemObj && itemObj.id && itemObj.wt && itemObj.nid !== wffGlobal.NODE_ID){
-            var ky = encoder.encode(event.key.substring(0, ndx));var wtBts = encoder.encode(itemObj.wt);var id = wffBMUtil.f15(itemObj.id);var v76;if(itemObj.removed){
-            var v46 = wffTaskUtil.f34(
+            var ky = encoder.encode(event.key.substring(0, ndx));var wtBts = encoder.encode(itemObj.wt);var id = wffBMUtil.f16(itemObj.id);var v76;if(itemObj.removed){
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             wffGlobal.taskValues.REMOVE_LS_TOKEN);var v84 = {
             'name': id,
             'values': [ky, wtBts]
             };v76 = [v46, v84];}else{
-            var v46 = wffTaskUtil.f34(
+            var v46 = wffTaskUtil.f35(
             wffGlobal.taskValues.TASK,
             wffGlobal.taskValues.SET_LS_TOKEN);var v84 = {
             'name': id,
             'values': [ky, encoder.encode(itemObj.v), wtBts]
             };v76 = [v46, v84];}
-            var wffBM = wffBMUtil.f13(v76);wffWS.send(wffBM);}
+            var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);}
             }else if(event.key === 'WFF_EXEC_JS'){
             var json = JSON.parse(event.newValue);if(json.js && json.instanceId && json.instanceId !== wffGlobal.INSTANCE_ID){
             if(window.execScript){

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlTest.java
@@ -2770,17 +2770,17 @@ public class AbstractHtmlTest {
 
         StringBuilder controlFlow = new StringBuilder();
 
-        AbstractHtml div1 = new Div(null).whenURI((uri) -> uri.startsWith(uri1), () -> {
+        AbstractHtml div1 = new Div(null).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(uri1), () -> {
 
             controlFlow.append("div1.whenURI\n");
 
-            AbstractHtml span = new Span(null).whenURI((uri) -> uri.startsWith(uri11), () -> {
+            AbstractHtml span = new Span(null).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(uri11), () -> {
 
                 controlFlow.append("span.whenURI\n");
 
                 AbstractHtml pParent = new CustomTag("p-parent", null).give(custom -> {
                     controlFlow.append("pParent.give\n");
-                    AbstractHtml p = new P(custom).whenURI((uri) -> uri.startsWith(uri111), () -> {
+                    AbstractHtml p = new P(custom).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(uri111), () -> {
 
                         controlFlow.append("p.whenURI\n");
 
@@ -2866,17 +2866,17 @@ public class AbstractHtmlTest {
 
         StringBuilder controlFlow = new StringBuilder();
 
-        AbstractHtml div1 = new Div(null).whenURI((uri) -> uri.startsWith(uri1), (event) -> {
+        AbstractHtml div1 = new Div(null).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(uri1), (event) -> {
 
             controlFlow.append("div1.whenURI\n");
 
-            AbstractHtml span = new Span(null).whenURI((uri) -> uri.startsWith(uri11), (event1) -> {
+            AbstractHtml span = new Span(null).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(uri11), (event1) -> {
 
                 controlFlow.append("span.whenURI\n");
 
                 AbstractHtml pParent = new CustomTag("p-parent", null).give(custom -> {
                     controlFlow.append("pParent.give\n");
-                    AbstractHtml p = new P(custom).whenURI((uri) -> uri.startsWith(uri111), (event2) -> {
+                    AbstractHtml p = new P(custom).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(uri111), (event2) -> {
 
                         controlFlow.append("p.whenURI\n");
 

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/WhenURIUseCaseTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/WhenURIUseCaseTest.java
@@ -73,7 +73,7 @@ public class WhenURIUseCaseTest {
 
         StringBuilder controlFlow = new StringBuilder();
 
-        AbstractHtml div1 = new Div(null).whenURI((uri) -> uri.startsWith(initialUri), () -> {
+        AbstractHtml div1 = new Div(null).whenURI((uriEvent) -> uriEvent.uriAfter().startsWith(initialUri), () -> {
 
             controlFlow.append("div1.whenURI\n");
 
@@ -99,7 +99,7 @@ public class WhenURIUseCaseTest {
 
         StringBuilder controlFlow = new StringBuilder();
 
-        AbstractHtml div1 = new Div(null).whenURI(uri -> uri.startsWith(initialUri), (event) -> {
+        AbstractHtml div1 = new Div(null).whenURI(uriEvent -> uriEvent.uriAfter().startsWith(initialUri), (event) -> {
 
             controlFlow.append("div1.whenURI\n");
 
@@ -127,14 +127,14 @@ public class WhenURIUseCaseTest {
         StringBuilder controlFlow = new StringBuilder();
         
         AbstractHtml div3 = new Div(null, new Name("div3-" + counter.incrementAndGet()));
-        div3.whenURI(uri -> uri.startsWith(uri111), () -> {
+        div3.whenURI(uriEvent -> uriEvent.uriAfter().startsWith(uri111), () -> {
 
             controlFlow.append("div3.whenURI1+");
 
             return new AbstractHtml[] {new NoTag(null, "somecontent1 uri111")};
         }).currentAs();
         
-        div3.whenURI(uri -> uri.startsWith(uri112), () -> {
+        div3.whenURI(uriEvent -> uriEvent.uriAfter().startsWith(uri112), () -> {
 
             controlFlow.append("div3.whenURI2+");
 
@@ -142,7 +142,7 @@ public class WhenURIUseCaseTest {
         }).currentAs();
         
         
-        AbstractHtml div2 = new Div(null, new Name("div2-" + counter.incrementAndGet())).whenURI(uri -> uri.startsWith(uri11), () -> {
+        AbstractHtml div2 = new Div(null, new Name("div2-" + counter.incrementAndGet())).whenURI(uriEvent -> uriEvent.uriAfter().startsWith(uri11), () -> {
 
             controlFlow.append("div2.whenURI+");
 
@@ -150,7 +150,7 @@ public class WhenURIUseCaseTest {
         }).currentAs();
         
         
-        AbstractHtml div1 = new Div(null, new Name("div1-" + counter.incrementAndGet())).whenURI(uri -> uri.startsWith(uri1), () -> {
+        AbstractHtml div1 = new Div(null, new Name("div1-" + counter.incrementAndGet())).whenURI(uriEvent -> uriEvent.uriAfter().startsWith(uri1), () -> {
 
             controlFlow.append("div1.whenURI+");
 
@@ -241,5 +241,41 @@ public class WhenURIUseCaseTest {
             } 
         }
        
+    }
+    
+    @Test
+    public void testUsage4() {
+
+        StringBuilder controlFlow = new StringBuilder();
+        
+        AbstractHtml someWrapper = new Div(null).give(dv -> {
+            AbstractHtml div1 = new Div(dv).whenURI(uriEvent -> uriEvent.uriAfter().startsWith("unmatched"), event -> {
+
+                controlFlow.append("success.whenURI\n");
+
+                event.sourceTag().addInnerHtmls(new AbstractHtml[] { new NoTag(null, "somecontent1") });
+            }, event -> {
+
+                controlFlow.append("fail.whenURI\n");
+
+                event.sourceTag().addInnerHtmls(new AbstractHtml[] { new NoTag(null, "somecontent2") });
+            }).currentAs();
+            
+        });
+
+        
+
+        mainDiv.appendChild(someWrapper);
+        assertEquals("fail.whenURI\n", controlFlow.toString());
+//        assertEquals("<div data-wff-id=\"S3\">somecontent2</div>", div1.toBigHtmlString());
+
+        browserPage.setURI(uri1);
+
+        assertEquals("fail.whenURI\nfail.whenURI\n", controlFlow.toString());
+//        assertEquals("<div data-wff-id=\"S3\">somecontent2</div>", div1.toBigHtmlString());
+        
+        browserPage.setURI("changeduri");
+        assertEquals("fail.whenURI\nfail.whenURI\nfail.whenURI\n", controlFlow.toString());
+
     }
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/WhenURIUseCaseTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/WhenURIUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.webfirmframework.wffweb.tag.html;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -277,5 +278,28 @@ public class WhenURIUseCaseTest {
         browserPage.setURI("changeduri");
         assertEquals("fail.whenURI\nfail.whenURI\nfail.whenURI\n", controlFlow.toString());
 
+    }
+    
+    @Test
+    public void testGetURI() {
+        
+        BrowserPage browserPage = new BrowserPage() {
+
+            @Override
+            public String webSocketUrl() {
+                // TODO Auto-generated method stub
+                return "wss://wffweb";
+            }
+
+            @Override
+            public AbstractHtml render() {
+                return new Html(null);
+            }
+
+        };
+        assertNull(browserPage.getURI());
+        browserPage.toHtmlString();
+        assertNull(browserPage.getURI());
+        
     }
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attributewff/ImmutableCustomAttributeTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attributewff/ImmutableCustomAttributeTest.java
@@ -1,0 +1,29 @@
+package com.webfirmframework.wffweb.tag.html.attributewff;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class ImmutableCustomAttributeTest {
+
+    @Test
+    public void testImmutableCustomAttributeString() {
+        ImmutableCustomAttribute attribute = new ImmutableCustomAttribute("attr-name");
+        assertEquals("attr-name", attribute.toHtmlString());
+    }
+
+    @Test
+    public void testImmutableCustomAttributeStringString() {
+        ImmutableCustomAttribute attribute = new ImmutableCustomAttribute("attr-name", "attr-value");
+        assertEquals("attr-name=\"attr-value\"", attribute.toHtmlString());
+    }
+
+    @Test
+    public void testGetValue() {
+        ImmutableCustomAttribute attribute = new ImmutableCustomAttribute("attr-name", "attr-value");
+        assertEquals("attr-value", attribute.getValue());
+        assertEquals("attr-value", attribute.getAttributeValue());
+        assertEquals("attr-name", attribute.getAttributeName());        
+    }
+
+}


### PR DESCRIPTION
Minor bug fix in the whenURI implementation.

Enhanced whenURI feature, now the whenURI predicate method param is `URIEvent` which contains details such as the changed uri, previous uri etc...

Now, the client side and server side `setURI` methods also accepts one more argument called replace, it is a boolean argument. If true is passed the current uri in the browser history will be replaced with the new one.
Usage at client side: `wffAsync.setURI("/user/items/", preFunction, postFunction, true);`
Usage at server side: `browserPage.setURI("/user/items", true);`

It also contains some internal security improvements.

`ImmutableCustomAttribute` is implemented to create immutable attribute object. It is similar to `CustomAttribute` but the only difference is it doesn't contain any public methods to change its value.

`AbstractAttribute.unsetOwnerTag` method is deprecated for removal, it is only for the internal use.