### PR TITLE
wffweb-12.0.0-beta.6 release changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://img.shields.io/badge/build-passing-greensvg?style=flat)](https://app.circleci.com/pipelines/github/webfirmframework/wff?branch=master&filter=all)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/410601e16dc54b0a973c03845ad790c2)](https://www.codacy.com/app/webfirm-framework/wff?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=webfirmframework/wff&amp;utm_campaign=Badge_Grade)
 [![Stackoverflow](https://img.shields.io/badge/stackoverflow-wffweb-orange.svg)](https://stackoverflow.com/questions/tagged/wffweb)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.webfirmframework/wffweb/badge.svg)](https://search.maven.org/#artifactdetails%7Ccom.webfirmframework%7Cwffweb%7C12.0.0-beta.5%7Cjar)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.webfirmframework/wffweb/badge.svg)](https://search.maven.org/#artifactdetails%7Ccom.webfirmframework%7Cwffweb%7C12.0.0-beta.6%7Cjar)
 [![javadoc](https://img.shields.io/:wffweb-javadoc-blue.svg)](https://webfirmframework.github.io/wffweb/wffweb-javadoc)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 [![twitter](https://img.shields.io/badge/twitter-@wffweb-blue.svg)](https://webfirmframework.com/twitter)
@@ -22,7 +22,7 @@ To support us please donate anything you wish to the author of this framework!
 ##### [check out wffweb-3.x.x sample projects](https://github.com/webfirmframework/minimal-production-ready-projects)
 
 
-##### check out this demo app deployed at [https://webfirmframework.com/demo/](https://webfirmframework.com/demo/)
+##### check out [this sample project](https://github.com/webfirmframework/wffweb-demo-deployment) deployed at [https://webfirmframework.com/demo/](https://webfirmframework.com/demo/)
 
 
 (For the survival of this framework, some ads are shown in [webfirmframework.github.io](https://webfirmframework.github.io) and [webfirmframework.com](https://webfirmframework.com) web sites. These are temporary ads and will be removed soon. We are really sorry if it causes any inconvenience to your surfing.)   

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.0.0-SNAPSHOT</version>
+	<version>12.0.0-beta.6</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.0.0-beta.5</version>
+	<version>12.0.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
@@ -368,7 +368,7 @@ public final class JsUtil {
      *             method. It does the same job.
      */
     @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
-    public static String toDynamicJs(final String s) {
+    static String toDynamicJs(final String s) {
 
         final int[] codePoints = strip(s.codePoints().toArray());
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -3033,6 +3033,7 @@ public abstract class BrowserPage implements Serializable {
                 try {
                     Files.createDirectories(dirPath);
                     tempDirPath = dirPath;
+                    return dirPath;
                 } catch (final IOException e) {
                     LOGGER.severe(
                             "The given path by useExternalDrivePath is invalid or it doesn't have read/write permission.");

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -16,6 +16,7 @@
 package com.webfirmframework.wffweb.server.page;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serial;
 import java.io.Serializable;
@@ -57,6 +58,7 @@ import java.util.logging.Logger;
 
 import com.webfirmframework.wffweb.InvalidUsageException;
 import com.webfirmframework.wffweb.InvalidValueException;
+import com.webfirmframework.wffweb.MethodNotImplementedException;
 import com.webfirmframework.wffweb.NotRenderedException;
 import com.webfirmframework.wffweb.NullValueException;
 import com.webfirmframework.wffweb.PushFailedException;
@@ -2148,6 +2150,29 @@ public abstract class BrowserPage implements Serializable {
      */
     public final void addServerMethod(final String methodName, final ServerMethod serverMethod) {
         serverMethods.put(methodName, new ServerMethodWrapper(serverMethod, null));
+    }
+
+    /**
+     * @param methodName   the method to invoke
+     * @param data         the data to be found in the event argument or null
+     * @param uri          the uri or null
+     * @param inputStream  the inputStream object or null
+     * @param outputStream the outputStream object or null
+     * @return the object returned by
+     *         {@link ServerMethod#invoke(ServerMethod.Event)} method.
+     * @since 12.0.0-beta.6
+     */
+    public final WffBMObject invokeServerMethod(final String methodName, final WffBMObject data, final String uri,
+            final InputStream inputStream, final OutputStream outputStream) {
+        final ServerMethodWrapper serverMethodWrapper = serverMethods.get(methodName);
+        if (serverMethodWrapper != null) {
+            final ServerMethod serverMethod = serverMethodWrapper.serverMethod();
+            if (serverMethod != null) {
+                return serverMethod.invoke(new ServerMethod.Event(data, methodName,
+                        serverMethodWrapper.serverSideData(), uri, inputStream, outputStream));
+            }
+        }
+        throw new MethodNotImplementedException(methodName + " is not added by browserPage.addServerMethod method");
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -3038,7 +3038,6 @@ public abstract class BrowserPage implements Serializable {
                             "The given path by useExternalDrivePath is invalid or it doesn't have read/write permission.");
                 }
             }
-
         }
 
         return tempDirPath;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -2149,7 +2149,7 @@ public abstract class BrowserPage implements Serializable {
      * @since 2.1.0
      */
     public final void addServerMethod(final String methodName, final ServerMethod serverMethod) {
-        serverMethods.put(methodName, new ServerMethodWrapper(serverMethod, null));
+        addServerMethod(methodName, serverMethod, null);
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -3027,7 +3027,7 @@ public abstract class BrowserPage implements Serializable {
      * @since 12.0.0-beta.6
      */
     public Path getTempDirectory() {
-        if (externalDrivePath != null && tempDirPath != null) {
+        if (tempDirPath == null && externalDrivePath != null) {
             final Path dirPath = Paths.get(externalDrivePath, instanceId, "temp");
             if (Files.notExists(dirPath)) {
                 try {
@@ -3038,6 +3038,7 @@ public abstract class BrowserPage implements Serializable {
                             "The given path by useExternalDrivePath is invalid or it doesn't have read/write permission.");
                 }
             }
+
         }
 
         return tempDirPath;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -249,7 +249,7 @@ public abstract class BrowserPage implements Serializable {
      * To specify (by removeFromContext method) when to remove {@code BrowserPage}
      * instance from {@code BrowserPageContext}.
      *
-     * @author WFF
+     *
      * @since 2.1.4
      */
     public enum On {
@@ -352,7 +352,7 @@ public abstract class BrowserPage implements Serializable {
 
     /**
      * @param wsListener
-     * @author WFF
+     *
      * @since 2.0.0
      */
     public final void setWebSocketPushListener(final WebSocketPushListener wsListener) {
@@ -370,7 +370,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @param sessionId  the unique id of WebSocket session
      * @param wsListener
-     * @author WFF
+     *
      * @since 2.1.0
      */
     public final void addWebSocketPushListener(final String sessionId, final WebSocketPushListener wsListener) {
@@ -396,7 +396,7 @@ public abstract class BrowserPage implements Serializable {
      * removes the WebSocket listener added for this WebSocket session
      *
      * @param sessionId the unique id of WebSocket session
-     * @author WFF
+     *
      * @since 2.1.0
      */
     public final void removeWebSocketPushListener(final String sessionId) {
@@ -415,7 +415,7 @@ public abstract class BrowserPage implements Serializable {
     /**
      * removes all WebSocket listeners added
      *
-     * @author WFF
+     *
      * @since 3.0.16
      */
     final void clearWSListeners() {
@@ -623,7 +623,7 @@ public abstract class BrowserPage implements Serializable {
 
     /**
      * @param message the bytes the received in onmessage
-     * @author WFF
+     *
      * @since 2.1.0
      */
     public final void webSocketMessaged(final byte[] message) {
@@ -733,7 +733,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @return the object of {@link Html} class which needs to be displayed in the
      *         client browser page.
-     * @author WFF
+     *
      */
     public abstract AbstractHtml render();
 
@@ -997,7 +997,7 @@ public abstract class BrowserPage implements Serializable {
      *                                      implementation will never make this
      *                                      exception due to the code changes since
      *                                      3.0.1.
-     * @author WFF
+     *
      * @since 2.0.0
      */
     private void executeWffBMTask(final byte[] message) throws UnsupportedEncodingException {
@@ -1667,7 +1667,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @return {@code String} equalent to the html string of the tag including the
      *         child tags.
-     * @author WFF
+     *
      */
     public String toHtmlString() {
         initAbstractHtml();
@@ -1691,7 +1691,7 @@ public abstract class BrowserPage implements Serializable {
      * @param rebuild true to rebuild &amp; false to return previously built string.
      * @return {@code String} equalent to the html string of the tag including the
      *         child tags.
-     * @author WFF
+     *
      * @since 2.1.4
      */
     public String toHtmlString(final boolean rebuild) {
@@ -2111,7 +2111,7 @@ public abstract class BrowserPage implements Serializable {
 
     /**
      * @return a unique id for this instance
-     * @author WFF
+     *
      * @since 2.0.0
      */
     public final String getInstanceId() {
@@ -2143,7 +2143,7 @@ public abstract class BrowserPage implements Serializable {
     /**
      * @param methodName
      * @param serverMethod
-     * @author WFF
+     *
      * @since 2.1.0
      */
     public final void addServerMethod(final String methodName, final ServerMethod serverMethod) {
@@ -2155,7 +2155,7 @@ public abstract class BrowserPage implements Serializable {
      * @param serverMethod
      * @param serverSideData this object will be available in the event of
      *                       serverMethod.invoke
-     * @author WFF
+     *
      * @since 3.0.2
      */
     public final void addServerMethod(final String methodName, final ServerMethod serverMethod,
@@ -2167,7 +2167,7 @@ public abstract class BrowserPage implements Serializable {
      * removes the method from
      *
      * @param methodName
-     * @author WFF
+     *
      * @since 2.1.0
      */
     public final void removeServerMethod(final String methodName) {
@@ -2180,7 +2180,7 @@ public abstract class BrowserPage implements Serializable {
      * @param actionByteBuffer The ByteBuffer object taken from
      *                         {@code BrowserPageAction} .Eg:-
      *                         {@code BrowserPageAction.RELOAD.getActionByteBuffer();}
-     * @author WFF
+     *
      * @since 2.1.0
      */
     public final void performBrowserPageAction(final ByteBuffer actionByteBuffer) {
@@ -2236,7 +2236,7 @@ public abstract class BrowserPage implements Serializable {
      * }
      * </pre>
      *
-     * @author WFF
+     *
      * @since 2.1.3
      */
     public final void holdPush() {
@@ -2259,7 +2259,7 @@ public abstract class BrowserPage implements Serializable {
      * }
      * </pre>
      *
-     * @author WFF
+     *
      * @since 2.1.3
      */
     public final void unholdPush() {
@@ -2353,7 +2353,7 @@ public abstract class BrowserPage implements Serializable {
      * updates from server when the pushQueueSize exceeds a particular limit.
      *
      * @return the size of internal push queue.
-     * @author WFF
+     *
      * @since 2.1.4
      */
     public final int getPushQueueSize() {
@@ -2372,7 +2372,7 @@ public abstract class BrowserPage implements Serializable {
      * @param enable
      * @param ons    the instance of On to represent on which browser event the
      *               browser page needs to be removed.
-     * @author WFF
+     *
      * @since 2.1.4
      */
     public final void removeFromContext(final boolean enable, final On... ons) {
@@ -2409,7 +2409,7 @@ public abstract class BrowserPage implements Serializable {
      * Invokes when this browser page instance is removed from browser page context.
      * Override and use this method to stop long-running tasks / threads.
      *
-     * @author WFF
+     *
      * @since 2.1.4
      */
     protected void removedFromContext() {
@@ -2431,7 +2431,7 @@ public abstract class BrowserPage implements Serializable {
      *                              {@code browserPage#toHtmlString} or
      *                              {@code browserPage#toOutputStream} was NOT
      *                              called at least once in the life time.
-     * @author WFF
+     *
      * @since 2.1.7
      */
     public final boolean contains(final AbstractHtml tag) throws NullValueException, NotRenderedException {
@@ -2461,7 +2461,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @param milliseconds the heartbeat ping interval of webSocket client in
      *                     milliseconds. Give -1 to disable it.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     protected final void setWebSocketHeartbeatInterval(final int milliseconds) {
@@ -2471,7 +2471,7 @@ public abstract class BrowserPage implements Serializable {
     /**
      * @return the interval value set by
      *         {@code BrowserPage#setWebSocketHeartbeatInterval(int)} method.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     public final int getWebSocketHeartbeatInterval() {
@@ -2487,7 +2487,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @param milliseconds the heartbeat ping interval of webSocket client in
      *                     milliseconds. Give -1 to disable it
-     * @author WFF
+     *
      * @since 2.1.8
      * @since 2.1.9 the default value is 25000ms i.e. 25 seconds.
      */
@@ -2498,7 +2498,7 @@ public abstract class BrowserPage implements Serializable {
     /**
      * @return the interval value set by {@code setWebSocketDefultHeartbeatInterval}
      *         method.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     public static final int getWebSocketDefultHeartbeatInterval() {
@@ -2513,7 +2513,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @param milliseconds the reconnect interval of webSocket client in
      *                     milliseconds. It must be greater than 0.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     public static final void setWebSocketDefultReconnectInterval(final int milliseconds) {
@@ -2526,7 +2526,7 @@ public abstract class BrowserPage implements Serializable {
     /**
      * @return the interval value set by {@code setWebSocketDefultReconnectInterval}
      *         method.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     public static final int getWebSocketDefultReconnectInterval() {
@@ -2545,7 +2545,7 @@ public abstract class BrowserPage implements Serializable {
      *
      * @param milliseconds the reconnect interval of webSocket client in
      *                     milliseconds. Give -1 to disable it.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     protected final void setWebSocketReconnectInterval(final int milliseconds) {
@@ -2555,7 +2555,7 @@ public abstract class BrowserPage implements Serializable {
     /**
      * @return the interval value set by
      *         {@code BrowserPage#setWebSocketReconnectInterval(int)} method.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     public final int getWebSocketReconnectInterval() {
@@ -2569,7 +2569,7 @@ public abstract class BrowserPage implements Serializable {
      * @return the TagRepository object to do different tag operations. Or null if
      *         any one of the BrowserPage#toString or BrowserPage#toOutputStream
      *         methods is not called.
-     * @author WFF
+     *
      * @since 2.1.8
      */
     public final TagRepository getTagRepository() {
@@ -3020,8 +3020,8 @@ public abstract class BrowserPage implements Serializable {
      * It will provide you a unique temporary directory path for this BrowserPage
      * instance. This temp directory and all of its sub-directories/files will be
      * deleted after this BrowserPage instance is garbage collected. You should
-     * override {@code useExternalDrivePath()} and return a valid path in it. The
-     * returned path should have read & write permission.
+     * override {@link #useExternalDrivePath()} and return a valid path in it. The
+     * returned path should have read &amp; write permission.
      *
      * @return the temporary directory if useExternalDrivePath is set
      * @since 12.0.0-beta.6

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -2928,41 +2928,10 @@ public abstract class BrowserPage implements Serializable {
     /**
      * Override and use
      *
-     * @param uriBefore
-     * @param uriAfter
-     * @param initiator
-     * @since 12.0.0-beta.1
-     * @deprecated override and use {@link BrowserPage#beforeURIChange(URIEvent)}
-     *             instead of this method.
-     */
-    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
-    protected void beforeURIChange(final String uriBefore, final String uriAfter, final URIEventInitiator initiator) {
-
-    }
-
-    /**
-     * Override and use
-     *
-     * @param uriBefore
-     * @param uriAfter
-     * @param initiator
-     * @since 12.0.0-beta.4
-     * @deprecated override and use {@link BrowserPage#afterURIChange(URIEvent)}
-     *             instead of this method.
-     */
-    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
-    protected void afterURIChange(final String uriBefore, final String uriAfter, final URIEventInitiator initiator) {
-
-    }
-
-    /**
-     * Override and use
-     *
      * @param uriEvent
      * @since 12.0.0-beta.5
      */
     protected URIEventMask beforeURIChange(final URIEvent uriEvent) {
-        beforeURIChange(uriEvent.uriBefore(), uriEvent.uriAfter(), uriEvent.initiator());
         return null;
     }
 
@@ -2973,7 +2942,6 @@ public abstract class BrowserPage implements Serializable {
      * @since 12.0.0-beta.5
      */
     protected void afterURIChange(final URIEvent uriEvent) {
-        afterURIChange(uriEvent.uriBefore(), uriEvent.uriAfter(), uriEvent.initiator());
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -16,7 +16,6 @@
 package com.webfirmframework.wffweb.server.page;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serial;
 import java.io.Serializable;
@@ -2153,23 +2152,20 @@ public abstract class BrowserPage implements Serializable {
     }
 
     /**
-     * @param methodName   the method to invoke
-     * @param data         the data to be found in the event argument or null
-     * @param uri          the uri or null
-     * @param inputStream  the inputStream object or null
-     * @param outputStream the outputStream object or null
+     * @param methodName the method to invoke
+     * @param recordData the recordData to be found in the event argument or null
+     * @param uri        the uri or null
      * @return the object returned by
      *         {@link ServerMethod#invoke(ServerMethod.Event)} method.
      * @since 12.0.0-beta.6
      */
-    public final WffBMObject invokeServerMethod(final String methodName, final WffBMObject data, final String uri,
-            final InputStream inputStream, final OutputStream outputStream) {
+    public final WffBMObject invokeServerMethod(final String methodName, final Record recordData, final String uri) {
         final ServerMethodWrapper serverMethodWrapper = serverMethods.get(methodName);
         if (serverMethodWrapper != null) {
             final ServerMethod serverMethod = serverMethodWrapper.serverMethod();
             if (serverMethod != null) {
-                return serverMethod.invoke(new ServerMethod.Event(data, methodName,
-                        serverMethodWrapper.serverSideData(), uri, inputStream, outputStream));
+                return serverMethod.invoke(
+                        new ServerMethod.Event(methodName, serverMethodWrapper.serverSideData(), uri, recordData));
             }
         }
         throw new MethodNotImplementedException(methodName + " is not added by browserPage.addServerMethod method");

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -3032,12 +3032,12 @@ public abstract class BrowserPage implements Serializable {
             if (Files.notExists(dirPath)) {
                 try {
                     Files.createDirectories(dirPath);
+                    tempDirPath = dirPath;
                 } catch (final IOException e) {
                     LOGGER.severe(
                             "The given path by useExternalDrivePath is invalid or it doesn't have read/write permission.");
                 }
             }
-            tempDirPath = dirPath;
         }
 
         return tempDirPath;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPageContext.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPageContext.java
@@ -265,11 +265,13 @@ public enum BrowserPageContext {
      */
     public BrowserPage getBrowserPageIfValid(final String instanceId) {
         final BrowserPage browserPage = instanceIdBrowserPage.get(instanceId);
-        final MinIntervalExecutor autoCleanTaskExecutor = this.autoCleanTaskExecutor;
-        if (autoCleanTaskExecutor != null) {
-            if ((System.currentTimeMillis() - browserPage.getLastClientAccessedTime()) >= autoCleanTaskExecutor
-                    .minInterval()) {
-                return null;
+        if (browserPage != null) {
+            final MinIntervalExecutor autoCleanTaskExecutor = this.autoCleanTaskExecutor;
+            if (autoCleanTaskExecutor != null) {
+                if ((System.currentTimeMillis() - browserPage.getLastClientAccessedTime()) >= autoCleanTaskExecutor
+                        .minInterval()) {
+                    return null;
+                }
             }
         }
         return browserPage;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/core/AbstractJsObject.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/core/AbstractJsObject.java
@@ -73,10 +73,13 @@ public abstract sealed class AbstractJsObject extends AbstractTagBase permits Ab
      */
     private Map<String, WffBMData> getWffDatas() {
         if (wffBMDatas == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 if (wffBMDatas == null) {
                     wffBMDatas = new ConcurrentHashMap<>();
                 }
+            } finally {
+                commonLock().unlock();
             }
         }
         return wffBMDatas;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/core/AbstractTagBase.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/core/AbstractTagBase.java
@@ -16,15 +16,23 @@
  */
 package com.webfirmframework.wffweb.tag.core;
 
+import java.util.concurrent.locks.ReentrantLock;
+
 import com.webfirmframework.wffweb.tag.html.attribute.core.AbstractAttribute;
 
 /**
  * @author WFF
  *
  */
-public abstract sealed class AbstractTagBase implements TagBase permits AbstractJsObject,AbstractAttribute {
+public abstract sealed class AbstractTagBase implements TagBase permits AbstractJsObject, AbstractAttribute {
 
     private static final long serialVersionUID = 1_0_0L;
+
+    /**
+     * replacement lock for synchronized block. i.e. synchronized (this) may be
+     * replaced with this lock
+     */
+    private final ReentrantLock commonLock = new ReentrantLock();
 
     private volatile boolean rebuild = true;
 
@@ -105,4 +113,14 @@ public abstract sealed class AbstractTagBase implements TagBase permits Abstract
         this.data = data;
     }
 
+    /**
+     * replacement lock for synchronized block. i.e. synchronized (this) may be
+     * replaced with this lock
+     *
+     * @return ReentrantLock
+     * @since 12.0.0-beta.6
+     */
+    protected final ReentrantLock commonLock() {
+        return commonLock;
+    }
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -2361,12 +2361,15 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
         Map<String, AbstractAttribute> attributesMap = this.attributesMap;
         if (attributesMap == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 attributesMap = this.attributesMap;
                 if (attributesMap == null) {
                     attributesMap = new ConcurrentHashMap<>(attributes.length);
                     this.attributesMap = attributesMap;
                 }
+            } finally {
+                commonLock().unlock();
             }
         }
 
@@ -4361,10 +4364,13 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      */
     protected StringBuilder getHtmlMiddleSB() {
         if (htmlMiddleSB == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 if (htmlMiddleSB == null) {
                     htmlMiddleSB = new StringBuilder();
                 }
+            } finally {
+                commonLock().unlock();
             }
         }
         return htmlMiddleSB;
@@ -5409,12 +5415,15 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
     private void initDataWffId(final AbstractHtml5SharedObject sharedObject) {
         if (dataWffId == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 if (dataWffId == null) {
                     final DataWffId newDataWffId = sharedObject.getNewDataWffId(ACCESS_OBJECT);
                     addAttributesLockless(false, newDataWffId);
                     dataWffId = newDataWffId;
                 }
+            } finally {
+                commonLock().unlock();
             }
         } else {
             throw new WffRuntimeException("dataWffId already exists");
@@ -5436,7 +5445,8 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      */
     public void setDataWffId(final DataWffId dataWffId) {
         if (this.dataWffId == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 if (this.dataWffId == null) {
 
                     final Lock lock = lockAndGetWriteLock();
@@ -5448,6 +5458,8 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     }
 
                 }
+            } finally {
+                commonLock().unlock();
             }
         } else {
             throw new WffRuntimeException("dataWffId already exists");

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagEvent.java
@@ -17,16 +17,10 @@ package com.webfirmframework.wffweb.tag.html;
 
 import com.webfirmframework.wffweb.common.URIEvent;
 
+/**
+ * @param sourceTag
+ * @param uriEvent
+ * @since 12.0.0-beta.5
+ */
 public record TagEvent(AbstractHtml sourceTag, URIEvent uriEvent) {
-
-    /**
-     * @return the uri
-     * @deprecated This method will be removed in the next release, use
-     *             {@link #uriEvent()} and get the {@link URIEvent#uriAfter()}, i.e.
-     *             the current uri.
-     */
-    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
-    public String uri() {
-        return uriEvent.uriAfter();
-    }
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -517,10 +517,13 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      */
     protected Map<String, String> getAttributeValueMap() {
         if (attributeValueMap == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 if (attributeValueMap == null) {
                     setAttributeValueMap(new LinkedHashMap<String, String>());
                 }
+            } finally {
+                commonLock().unlock();
             }
         }
         return attributeValueMap;
@@ -1064,11 +1067,14 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      */
     protected Set<String> getAttributeValueSet() {
         if (attributeValueSet == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 if (attributeValueSet == null) {
                     // because the load factor is 0.75f
                     attributeValueSet = new LinkedHashSet<>(2);
                 }
+            } finally {
+                commonLock().unlock();
             }
         }
         return attributeValueSet;
@@ -1387,12 +1393,15 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
     public void addValueChangeListener(final AttributeValueChangeListener valueChangeListener) {
         Set<AttributeValueChangeListener> valueChangeListeners = this.valueChangeListeners;
         if (valueChangeListeners == null) {
-            synchronized (this) {
+            commonLock().lock();
+            try {
                 valueChangeListeners = this.valueChangeListeners;
                 if (valueChangeListeners == null) {
                     valueChangeListeners = new LinkedHashSet<>();
                     this.valueChangeListeners = valueChangeListeners;
                 }
+            } finally {
+                commonLock().unlock();
             }
         }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -1005,27 +1005,6 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      * @param ownerTag the ownerTag to unset
      * @return true if the given ownerTag is an owner of the attribute.
      * @author WFF
-     * @since 2.0.0
-     * @deprecated it is only for the internal purpose
-     */
-    @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
-    public boolean unsetOwnerTag(final AbstractHtml ownerTag) {
-        final long stamp = ownerTagsLock.writeLock();
-        final boolean result;
-        try {
-            result = ownerTags.remove(ownerTag);
-        } finally {
-            ownerTagsLock.unlockWrite(stamp);
-        }
-        return result;
-    }
-
-    /**
-     * NB:- this method is used for internal purpose, so it should not be consumed.
-     *
-     * @param ownerTag the ownerTag to unset
-     * @return true if the given ownerTag is an owner of the attribute.
-     * @author WFF
      * @since 3.0.15
      */
     final boolean unsetOwnerTagLockless(final AbstractHtml ownerTag) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/event/ServerMethod.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/event/ServerMethod.java
@@ -15,6 +15,8 @@
  */
 package com.webfirmframework.wffweb.tag.html.attribute.event;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
 
 import com.webfirmframework.wffweb.tag.html.AbstractHtml;
@@ -27,15 +29,47 @@ public interface ServerMethod extends Serializable {
     /**
      * Contains event data for {@link ServerMethod#invoke(Event)}.
      *
+     * @param data
      * @param sourceTag
      * @param sourceAttribute
      * @param serverMethodName
      * @param serverSideData
      * @param uri
-     *
+     * @param inputStream
+     * @param outputStream
      */
     public static record Event(WffBMObject data, AbstractHtml sourceTag, AbstractAttribute sourceAttribute,
-            String serverMethodName, Object serverSideData, String uri) {
+            String serverMethodName, Object serverSideData, String uri, InputStream inputStream,
+            OutputStream outputStream) {
+
+        /**
+         * @param data
+         * @param sourceTag
+         * @param sourceAttribute
+         * @param serverMethodName
+         * @param serverSideData
+         * @param uri
+         */
+        public Event(final WffBMObject data, final AbstractHtml sourceTag, final AbstractAttribute sourceAttribute,
+                final String serverMethodName, final Object serverSideData, final String uri) {
+            this(data, sourceTag, sourceAttribute, serverMethodName, serverSideData, uri, null, null);
+        }
+
+        /**
+         * Note: only for internal use.
+         *
+         * @param data
+         * @param serverMethodName
+         * @param serverSideData
+         * @param uri
+         * @param inputStream
+         * @param outputStream
+         * @since 12.0.0-beta.6
+         */
+        public Event(final WffBMObject data, final String serverMethodName, final Object serverSideData,
+                final String uri, final InputStream inputStream, final OutputStream outputStream) {
+            this(data, null, null, serverMethodName, serverSideData, uri, inputStream, outputStream);
+        }
 
         /**
          * @return the sourceTag

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/event/ServerMethod.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/event/ServerMethod.java
@@ -15,8 +15,6 @@
  */
 package com.webfirmframework.wffweb.tag.html.attribute.event;
 
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.Serializable;
 
 import com.webfirmframework.wffweb.tag.html.AbstractHtml;
@@ -35,12 +33,10 @@ public interface ServerMethod extends Serializable {
      * @param serverMethodName
      * @param serverSideData
      * @param uri
-     * @param inputStream
-     * @param outputStream
+     * @param recordData
      */
     public static record Event(WffBMObject data, AbstractHtml sourceTag, AbstractAttribute sourceAttribute,
-            String serverMethodName, Object serverSideData, String uri, InputStream inputStream,
-            OutputStream outputStream) {
+            String serverMethodName, Object serverSideData, String uri, Record recordData) {
 
         /**
          * @param data
@@ -52,23 +48,21 @@ public interface ServerMethod extends Serializable {
          */
         public Event(final WffBMObject data, final AbstractHtml sourceTag, final AbstractAttribute sourceAttribute,
                 final String serverMethodName, final Object serverSideData, final String uri) {
-            this(data, sourceTag, sourceAttribute, serverMethodName, serverSideData, uri, null, null);
+            this(data, sourceTag, sourceAttribute, serverMethodName, serverSideData, uri, null);
         }
 
         /**
          * Note: only for internal use.
          *
-         * @param data
          * @param serverMethodName
          * @param serverSideData
          * @param uri
-         * @param inputStream
-         * @param outputStream
+         * @param recordData
          * @since 12.0.0-beta.6
          */
-        public Event(final WffBMObject data, final String serverMethodName, final Object serverSideData,
-                final String uri, final InputStream inputStream, final OutputStream outputStream) {
-            this(data, null, null, serverMethodName, serverSideData, uri, inputStream, outputStream);
+        public Event(final String serverMethodName, final Object serverSideData, final String uri,
+                final Record recordData) {
+            this(null, null, null, serverMethodName, serverSideData, uri, recordData);
         }
 
         /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/model/AbstractHtml5SharedObject.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/model/AbstractHtml5SharedObject.java
@@ -18,10 +18,7 @@ package com.webfirmframework.wffweb.tag.html.model;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -46,7 +43,6 @@ import com.webfirmframework.wffweb.internal.tag.html.listener.ReplaceListener;
 import com.webfirmframework.wffweb.internal.tag.html.listener.URIChangeTagSupplier;
 import com.webfirmframework.wffweb.internal.tag.html.listener.WffBMDataDeleteListener;
 import com.webfirmframework.wffweb.internal.tag.html.listener.WffBMDataUpdateListener;
-import com.webfirmframework.wffweb.tag.core.AbstractTagBase;
 import com.webfirmframework.wffweb.tag.html.AbstractHtml;
 import com.webfirmframework.wffweb.tag.html.attribute.listener.AttributeValueChangeListener;
 import com.webfirmframework.wffweb.tag.html.html5.attribute.global.DataWffId;
@@ -62,8 +58,6 @@ public final class AbstractHtml5SharedObject implements Serializable {
     private static final long serialVersionUID = 1_0_1L;
 
     private boolean childModified;
-
-    private transient volatile Set<AbstractTagBase> rebuiltTags;
 
     private ChildTagAppendListener childTagAppendListener;
 
@@ -242,36 +236,6 @@ public final class AbstractHtml5SharedObject implements Serializable {
             throw new WffSecurityException("Not allowed to consume this method. This method is for internal use.");
         }
         this.childModified = childModified;
-    }
-
-    /**
-     * gets the set containing the objects which are rebuilt after modified by its
-     * {@code AbstractTagBase} method. NB:- only for internal use. currently it's
-     * not used anywhere
-     *
-     * @param accessObject
-     * @return the rebuiltTags
-     * @since 1.0.0
-     * @author WFF
-     * @deprecated only for internal use currently it's not used anywhere. Needs to
-     *             remove this method later.
-     */
-    @Deprecated
-    Set<AbstractTagBase> getRebuiltTags(final SecurityObject accessObject) {
-
-        // TODO remove this method later
-        if (accessObject == null || !(IndexedClassType.ABSTRACT_HTML.equals(accessObject.forClassType()))) {
-            throw new WffSecurityException("Not allowed to consume this method. This method is for internal use.");
-        }
-
-        if (rebuiltTags == null) {
-            synchronized (this) {
-                if (rebuiltTags == null) {
-                    rebuiltTags = Collections.newSetFromMap(new WeakHashMap<AbstractTagBase, Boolean>());
-                }
-            }
-        }
-        return rebuiltTags;
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/Blank.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/Blank.java
@@ -29,7 +29,7 @@ import com.webfirmframework.wffweb.tag.html.AbstractHtml;
  * @deprecated use {@link NoTag} instead of this class.
  */
 @Deprecated(forRemoval = true, since = "12.0.0-beta.1")
-public class Blank extends NoTag {
+class Blank extends NoTag {
 
     // TODO This class needs to be tested properly
 
@@ -43,7 +43,7 @@ public class Blank extends NoTag {
      *
      * @since 1.0.0
      */
-    public Blank(final AbstractHtml base, final AbstractHtml... children) {
+    Blank(final AbstractHtml base, final AbstractHtml... children) {
         super(base, children);
     }
 

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffAsync.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffAsync.js
@@ -196,7 +196,7 @@ window.wffAsync = new function() {
 	};
 
 };
-wffGlobal.frz(window.wffAsync, false);
+
 // sample usage
 //
 // wffAsync.serverMethod('methodName', {'key1':'hi'}).invoke(function(obj) {

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMCRUIDUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMCRUIDUtil.js
@@ -143,4 +143,3 @@ var wffBMCRUIDUtil = new function() {
 
 };
 
-wffGlobal.frz(wffBMCRUIDUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMClientEvents.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMClientEvents.js
@@ -109,4 +109,3 @@ var wffBMClientEvents = new function() {
 	};
 
 };
-wffGlobal.frz(wffBMClientEvents, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffBMUtil.js
@@ -395,4 +395,3 @@ var wffBMUtil = new function() {
 	this.getDoubleFromOptimizedBytes = getDoubleFromOptimizedBytes;
 
 };
-wffGlobal.frz(wffBMUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientCRUDUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientCRUDUtil.js
@@ -852,4 +852,3 @@ var wffClientCRUDUtil = new function() {
 	};
 
 };
-wffGlobal.frz(wffClientCRUDUtil, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientMethods.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffClientMethods.js
@@ -70,4 +70,3 @@ var wffClientMethods = new function() {
 		return true;
 	};
 };
-wffGlobal.frz(wffClientMethods, false);

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffGlobal.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffGlobal.js
@@ -114,18 +114,5 @@ window.wffGlobal = new function() {
 		this.decoder = new TextDecoder("utf-8");
 	}
 
-	//args: obj, deep freeze
-	var frz = ((typeof Object) !== "undefined" && Object.freeze) ? function(obj, d) {
-		if (d) {
-			for (var k in obj) {
-				var v = obj[k];
-				if (v && typeof v === "object") {
-					frz(v, d);
-				}
-			}
-		}
-		return Object.freeze(obj);
-	} : function(o, d) { };
-	this.frz = frz;
 };
-wffGlobal.frz(wffGlobal, true);
+

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffServerMethods.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffServerMethods.js
@@ -199,8 +199,3 @@ var wffServerMethods = new function () {
 };
 //never ever rename ia
 var wffSM = wffServerMethods;
-
-wffGlobal.frz(wffTaskUtil, false);
-wffGlobal.frz(wffSM, false);
-
-

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffTagUtil.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffTagUtil.js
@@ -368,4 +368,4 @@ var wffTagUtil = new function() {
 	};
 	
 };
-wffGlobal.frz(wffTagUtil, false);
+

--- a/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffWS.js
+++ b/wffweb/src/main/resources/com/webfirmframework/wffweb/internal/server/page/js/wffWS.js
@@ -185,4 +185,4 @@ var wffWS = new function() {
 		return -1;
 	};
 };
-wffGlobal.frz(wffWS, false);
+

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFileTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/internal/server/page/js/WffJsFileTest.java
@@ -51,7 +51,7 @@ public class WffJsFileTest {
             k += 1;}
             A.length = len;return A;};}());}window.wffGlobal = new function() {
             var wffId = -1;this.getUniqueWffIntId = function() {
-            return ++wffId;};this.CPRSD_DATA = true;this.NDXD_TGS = ["#","@","a","b","i","p","q","s","u","br","dd","dl","dt","em","h1","h2","h3","h4","h5","h6","hr","li","ol","rp","rt","td","th","tr","ul","bdi","bdo","col","del","dfn","div","img","ins","kbd","map","nav","pre","qfn","sub","sup","svg","var","wbr","abbr","area","base","body","cite","code","data","form","head","html","line","link","main","mark","math","menu","meta","path","rect","ruby","samp","span","text","time","aside","audio","embed","input","label","meter","param","small","style","table","tbody","tfoot","thead","title","track","video","button","canvas","circle","dialog","figure","footer","header","hgroup","iframe","keygen","legend","object","option","output","script","select","source","strong","address","article","caption","details","ellipse","picture","polygon","section","summary","basefont","colgroup","datalist","fieldset","menuitem","noscript","optgroup","polyline","progress","template","textarea","blockquote","figcaption"];this.NDXD_ATRBS = ["id","alt","dir","for","low","max","min","rel","rev","src","cols","face","form","high","href","lang","list","loop","name","open","role","rows","size","step","type","wrap","align","async","class","color","defer","ismap","media","muted","nonce","oncut","scope","shape","sizes","style","title","value","width","accept","action","border","coords","height","hidden","method","nohref","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","poster","sorted","srcset","target","usemap","charset","checked","colspan","content","default","dirname","enctype","headers","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","optimum","pattern","preload","rowspan","sandbox","autoplay","controls","datetime","disabled","download","dropzone","hreflang","multiple","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","readonly","required","reversed","selected","tabindex","accesskey","autofocus","draggable","maxlength","minlength","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","translate","formaction","formmethod","formtarget","http-equiv","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","spellcheck","cellpadding","cellspacing","contextmenu","data-wff-id","formenctype","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","placeholder","animationend","autocomplete","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","transitionend","accept-charset","animationstart","formnovalidate","onbeforeunload","onvolumechange","contenteditable","oncanplaythrough","ondurationchange","onloadedmetadata","animationiteration"];this.NDXD_VNT_ATRBS = ["oncut","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","onbeforeunload","onvolumechange","oncanplaythrough","ondurationchange","onloadedmetadata"];this.NDXD_BLN_ATRBS = ["open","async","defer","ismap","hidden","checked","default","controls","disabled","multiple","readonly","reversed","selected"];this.taskValues = {INITIAL_WS_OPEN:0,INVOKE_ASYNC_METHOD:1,ATTRIBUTE_UPDATED:2,TASK:3,APPENDED_CHILD_TAG:4,REMOVED_TAGS:5,APPENDED_CHILDREN_TAGS:6,REMOVED_ALL_CHILDREN_TAGS:7,MOVED_CHILDREN_TAGS:8,INSERTED_BEFORE_TAG:9,INSERTED_AFTER_TAG:10,REPLACED_WITH_TAGS:11,REMOVED_ATTRIBUTES:12,ADDED_ATTRIBUTES:13,MANY_TO_ONE:14,ONE_TO_MANY:15,MANY_TO_MANY:16,ONE_TO_ONE:17,ADDED_INNER_HTML:18,INVOKE_POST_FUNCTION:19,EXEC_JS:20,RELOAD_BROWSER:21,RELOAD_BROWSER_FROM_CACHE:22,INVOKE_CALLBACK_FUNCTION:23,INVOKE_CUSTOM_SERVER_METHOD:24,TASK_OF_TASKS:25,COPY_INNER_TEXT_TO_VALUE:26,REMOVE_BROWSER_PAGE:27,SET_BM_OBJ_ON_TAG:28,SET_BM_ARR_ON_TAG:29,DEL_BM_OBJ_OR_ARR_FROM_TAG:30,CLIENT_PATHNAME_CHANGED:31,AFTER_SET_URI:32,SET_URI:33,SET_LS_ITEM:34,SET_LS_TOKEN:35,GET_LS_ITEM:36,REMOVE_LS_ITEM:37,REMOVE_LS_TOKEN:38,REMOVE_AND_GET_LS_ITEM:39,CLEAR_LS:40};this.uriEventInitiator = {SERVER_CODE:0,CLIENT_CODE:1,BROWSER:2,size:3};this.WS_URL = "ws://webfirmframework.com";this.INSTANCE_ID = "instance-id-1234585-451";this.NODE_ID = "ec19a8a5-8d25-4ac1-83f6-19b0845556d2";this.REMOVE_PREV_BP_ON_INITTAB = true;this.REMOVE_PREV_BP_ON_TABCLOSE = true;this.WS_RECON = 2000;if ((typeof TextEncoder) === "undefined") {
+            return ++wffId;};this.CPRSD_DATA = true;this.NDXD_TGS = ["#","@","a","b","i","p","q","s","u","br","dd","dl","dt","em","h1","h2","h3","h4","h5","h6","hr","li","ol","rp","rt","td","th","tr","ul","bdi","bdo","col","del","dfn","div","img","ins","kbd","map","nav","pre","qfn","sub","sup","svg","var","wbr","abbr","area","base","body","cite","code","data","form","head","html","line","link","main","mark","math","menu","meta","path","rect","ruby","samp","span","text","time","aside","audio","embed","input","label","meter","param","small","style","table","tbody","tfoot","thead","title","track","video","button","canvas","circle","dialog","figure","footer","header","hgroup","iframe","keygen","legend","object","option","output","script","select","source","strong","address","article","caption","details","ellipse","picture","polygon","section","summary","basefont","colgroup","datalist","fieldset","menuitem","noscript","optgroup","polyline","progress","template","textarea","blockquote","figcaption"];this.NDXD_ATRBS = ["id","alt","dir","for","low","max","min","rel","rev","src","cols","face","form","high","href","lang","list","loop","name","open","role","rows","size","step","type","wrap","align","async","class","color","defer","ismap","media","muted","nonce","oncut","scope","shape","sizes","style","title","value","width","accept","action","border","coords","height","hidden","method","nohref","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","poster","sorted","srcset","target","usemap","charset","checked","colspan","content","default","dirname","enctype","headers","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","optimum","pattern","preload","rowspan","sandbox","autoplay","controls","datetime","disabled","download","dropzone","hreflang","multiple","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","readonly","required","reversed","selected","tabindex","accesskey","autofocus","draggable","maxlength","minlength","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","translate","formaction","formmethod","formtarget","http-equiv","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","spellcheck","cellpadding","cellspacing","contextmenu","data-wff-id","formenctype","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","placeholder","animationend","autocomplete","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","transitionend","accept-charset","animationstart","formnovalidate","onbeforeunload","onvolumechange","contenteditable","oncanplaythrough","ondurationchange","onloadedmetadata","animationiteration"];this.NDXD_VNT_ATRBS = ["oncut","onblur","oncopy","ondrag","ondrop","onload","onplay","onshow","onabort","onclick","onended","onerror","onfocus","oninput","onkeyup","onpaste","onpause","onreset","onwheel","onchange","ononline","onresize","onscroll","onsearch","onseeked","onselect","onsubmit","ontoggle","onunload","oncanplay","ondragend","onemptied","onfocusin","oninvalid","onkeydown","onmouseup","onoffline","onplaying","onseeking","onstalled","onstorage","onsuspend","onwaiting","ondblclick","ondragover","onfocusout","onkeypress","onmouseout","onpagehide","onpageshow","onpopstate","onprogress","ontouchend","ondragenter","ondragleave","ondragstart","onloadstart","onmousedown","onmousemove","onmouseover","ontouchmove","onafterprint","onhashchange","onloadeddata","onmouseenter","onmouseleave","onratechange","ontimeupdate","ontouchstart","onbeforeprint","oncontextmenu","ontouchcancel","onbeforeunload","onvolumechange","oncanplaythrough","ondurationchange","onloadedmetadata"];this.NDXD_BLN_ATRBS = ["open","async","defer","ismap","hidden","checked","default","controls","disabled","multiple","readonly","reversed","selected"];this.taskValues = {INITIAL_WS_OPEN:0,INVOKE_ASYNC_METHOD:1,ATTRIBUTE_UPDATED:2,TASK:3,APPENDED_CHILD_TAG:4,REMOVED_TAGS:5,APPENDED_CHILDREN_TAGS:6,REMOVED_ALL_CHILDREN_TAGS:7,MOVED_CHILDREN_TAGS:8,INSERTED_BEFORE_TAG:9,INSERTED_AFTER_TAG:10,REPLACED_WITH_TAGS:11,REMOVED_ATTRIBUTES:12,ADDED_ATTRIBUTES:13,MANY_TO_ONE:14,ONE_TO_MANY:15,MANY_TO_MANY:16,ONE_TO_ONE:17,ADDED_INNER_HTML:18,INVOKE_POST_FUNCTION:19,EXEC_JS:20,RELOAD_BROWSER:21,RELOAD_BROWSER_FROM_CACHE:22,INVOKE_CALLBACK_FUNCTION:23,INVOKE_CUSTOM_SERVER_METHOD:24,TASK_OF_TASKS:25,COPY_INNER_TEXT_TO_VALUE:26,REMOVE_BROWSER_PAGE:27,SET_BM_OBJ_ON_TAG:28,SET_BM_ARR_ON_TAG:29,DEL_BM_OBJ_OR_ARR_FROM_TAG:30,CLIENT_PATHNAME_CHANGED:31,AFTER_SET_URI:32,SET_URI:33,SET_LS_ITEM:34,SET_LS_TOKEN:35,GET_LS_ITEM:36,REMOVE_LS_ITEM:37,REMOVE_LS_TOKEN:38,REMOVE_AND_GET_LS_ITEM:39,CLEAR_LS:40};this.uriEventInitiator = {SERVER_CODE:0,CLIENT_CODE:1,BROWSER:2,size:3};this.WS_URL = "ws://webfirmframework.com";this.INSTANCE_ID = "instance-id-1234585-451";this.NODE_ID = "7479d235-7f41-445b-bbaa-ea56a88d19c6";this.REMOVE_PREV_BP_ON_INITTAB = true;this.REMOVE_PREV_BP_ON_TABCLOSE = true;this.WS_RECON = 2000;if ((typeof TextEncoder) === "undefined") {
             this.encoder = new function TextEncoder(charset) {
             if (charset === "utf-8") {
             this.encode = function(text) {
@@ -93,14 +93,7 @@ public class WffJsFileTest {
             return text;};}
             }("utf-8");} else {
             this.decoder = new TextDecoder("utf-8");}
-            var frz = ((typeof Object) !== "undefined" && Object.freeze) ? function(obj, d) {
-            if (d) {
-            for (var k in obj) {
-            var v = obj[k];if (v && typeof v === "object") {
-            frz(v, d);}
-            }
-            }
-            return Object.freeze(obj);} : function(o, d) { };this.frz = frz;};wffGlobal.frz(wffGlobal, true);var wffBMUtil = new function(){
+            };var wffBMUtil = new function(){
 
             this.f14 = function(v76){
             var v34 = 0;var v22 = 0;for (var i = 0; i < v76.length; i++){
@@ -197,7 +190,7 @@ public class WffJsFileTest {
             var f8 = function(bytes){
             var buffer = new ArrayBuffer(8);var int8Array = new Int8Array(buffer);for (var i = 0; i < bytes.length; i++){
             int8Array[i] = bytes[bytes.length - 1 - i];}
-            return new Float64Array(buffer)[0];};this.f8 = f8;};wffGlobal.frz(wffBMUtil, false);
+            return new Float64Array(buffer)[0];};this.f8 = f8;};
             var wffTagUtil = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f31 = function(utf8Bytes){
             return decoder.decode(new Uint8Array(utf8Bytes));};var subarray = wffBMUtil.subarray;var f5 = function(utf8Bytes){
@@ -275,7 +268,7 @@ public class WffJsFileTest {
             return parent;};if(wffGlobal.CPRSD_DATA){
             this.f19 = this.f2;}
             this.f22 = function(p, v20){
-            var i = wffBMUtil.f15(v20);return p.childNodes[i];};};wffGlobal.frz(wffTagUtil, false);
+            var i = wffBMUtil.f15(v20);return p.childNodes[i];};};
             var wffBMCRUIDUtil = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var encodedBytesForHash = encoder.encode('#');this.f18 = function(tag){
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("DT");var v46 = {
@@ -315,7 +308,7 @@ public class WffJsFileTest {
             var v76 = [];var tUtf8Bytes = encoder.encode("T");var cUtf8Bytes = encoder.encode("C");var v46 = {
             'name' : tUtf8Bytes,
             'values' : [ cUtf8Bytes ]
-            };v76.push(v46);var v61 = 0;f44(v76, tag, v61);v76[1].name = wffBMUtil.f16(v41);return wffBMUtil.f14(v76);};};wffGlobal.frz(wffBMCRUIDUtil, false);
+            };v76.push(v46);var v61 = 0;f44(v76, tag, v61);v76[1].name = wffBMUtil.f16(v41);return wffBMUtil.f14(v76);};};
             var wffClientCRUDUtil = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var uriChangeQ = [];var f31 = function(utf8Bytes){
             return decoder.decode(new Uint8Array(utf8Bytes));};var f45 = function(v76){
@@ -599,7 +592,7 @@ public class WffJsFileTest {
             }else{
             return false;}
             return true;};this.f30 = function(v79){
-            var v84 = wffBMUtil.f10(v79)[1];};};wffGlobal.frz(wffClientCRUDUtil, false);
+            var v84 = wffBMUtil.f10(v79)[1];};};
             var wffTaskUtil = new function (){
             var encoder = wffGlobal.encoder;this.f35 = function(v93, valueByte){
             var v46 = {
@@ -651,7 +644,7 @@ public class WffJsFileTest {
             event.preventDefault();}
             var v46 = wffTaskUtil.f35(wffGlobal.taskValues.TASK, wffGlobal.taskValues.INVOKE_ASYNC_METHOD);var v88 = f25(v70);var jsObject = filterFun(event, tag);var v32 = new WffBMObject(jsObject);var v94 = v32.getBMBytes();var v84 = {'name':wffTagUtil.f26(tag), 'values':[v88, v94]};var v76 = [v46, v84];var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};this.d = function(event, tag, v70, filterFun){
             f11(event, tag, v70, filterFun, true);};var invokeAsyncWithFilterFun = function(event, tag, v70, filterFun){
-            f11(event, tag, v70, filterFun, false);};this.c = invokeAsyncWithFilterFun;};var wffSM = wffServerMethods;wffGlobal.frz(wffTaskUtil, false);wffGlobal.frz(wffSM, false);
+            f11(event, tag, v70, filterFun, false);};this.c = invokeAsyncWithFilterFun;};var wffSM = wffServerMethods;
             var wffClientMethods = new function(){
             var f31 = function(utf8Bytes){
             return wffGlobal.decoder.decode(new Uint8Array(utf8Bytes));};this.exePostFun = function(v79){
@@ -673,7 +666,7 @@ public class WffJsFileTest {
             }
             cbFun(jsObject);delete wffAsync.v27[funKey];}else{
             return false;}
-            return true;};};wffGlobal.frz(wffClientMethods, false);
+            return true;};};
             var f36 = function(valueType){
             if(valueType === '[object String]'){
             return 0;}else if(valueType === '[object Number]'){
@@ -938,7 +931,7 @@ public class WffJsFileTest {
             } catch (e){
             wffLog("The second argument threw exception when wffAsync.setURI is called", e);}
             f9(uriAfter, callbackWrapper, wffGlobal.uriEventInitiator.CLIENT_CODE, replace);}
-            };};wffGlobal.frz(window.wffAsync, false);
+            };};
             var wffBMClientEvents = new function(){
             window.v1 = false;var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var f28 = function(wffInstanceId){
             var v76 = [];var v23 = encoder.encode(wffInstanceId);var tnv = wffTaskUtil.f35(
@@ -975,7 +968,7 @@ public class WffJsFileTest {
             'values': [bmBts]
             };v76.push(nv);}
             }
-            var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};};wffGlobal.frz(wffBMClientEvents, false);
+            var wffBM = wffBMUtil.f14(v76);wffWS.send(wffBM);};};
             var wffWS = new function(){
             var encoder = wffGlobal.encoder;var decoder = wffGlobal.decoder;var prevIntvl = null;var webSocket = null;var inDataQ = [];var sendQData = null;this.openSocket = function(wsUrl){
             if(webSocket !== null
@@ -1038,7 +1031,7 @@ public class WffJsFileTest {
             };this.getState = function(){
             if(webSocket !== null){
             return webSocket.readyState;}
-            return -1;};};wffGlobal.frz(wffWS, false);
+            return -1;};};
             document.addEventListener("DOMContentLoaded",
             function(event){
             var encoder = wffGlobal.encoder;if(typeof window.f38Invoked === 'undefined'){

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
@@ -17,6 +17,10 @@ package com.webfirmframework.wffweb.server.page;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -36,6 +40,7 @@ import com.webfirmframework.wffweb.tag.html.Body;
 import com.webfirmframework.wffweb.tag.html.Html;
 import com.webfirmframework.wffweb.tag.html.metainfo.Head;
 import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Div;
+import com.webfirmframework.wffweb.wffbm.data.WffBMObject;
 
 @SuppressWarnings("serial")
 public class BrowserPageTest {
@@ -246,6 +251,113 @@ public class BrowserPageTest {
     
     public static Set<Reference<AbstractHtml>> getTagsForURIChangeForTest(BrowserPage browserPage) {
         return browserPage.getTagsForURIChangeForTest();
+    }
+    
+    @Test
+    public void testInvokeServerMethod() {
+        BrowserPage browserPage = new BrowserPage() {
+
+            @Override
+            public String webSocketUrl() {
+                return "wss://webfirmframework.com/ws-con";
+            }
+
+            @Override
+            public AbstractHtml render() {
+                Html html = new Html(null) {
+                    {
+                        new Head(this);
+                        new Body(this);
+                    }
+                };
+                html.setPrependDocType(true);
+                return html;
+            }
+        };
+
+        final WffBMObject result = new WffBMObject();
+        final WffBMObject data = new WffBMObject();
+        final InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+        final OutputStream outputStream = new ByteArrayOutputStream();
+        final String uri = "/user";
+        final String customServerMethodName1 = "customServerMethod1";
+        final Object serverSideData = new String("someserversidedata");
+
+        browserPage.addServerMethod(customServerMethodName1, event -> {
+
+            assertNotNull(event);
+            assertEquals(data, event.data());
+            assertEquals(inputStream, event.inputStream());
+            assertEquals(outputStream, event.outputStream());
+            assertEquals(uri, event.uri());
+            assertEquals(customServerMethodName1, event.serverMethodName());
+            assertEquals(serverSideData, event.serverSideData());
+
+            assertNull(event.sourceTag());
+            assertNull(event.sourceAttribute());
+
+            return result;
+        }, serverSideData);
+
+        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+
+        browserPage.addServerMethod(customServerMethodName1, event -> {
+
+            assertNotNull(event);
+            assertEquals(data, event.data());
+            assertEquals(inputStream, event.inputStream());
+            assertEquals(outputStream, event.outputStream());
+            assertEquals(uri, event.uri());
+            assertEquals(customServerMethodName1, event.serverMethodName());
+            assertEquals(customServerMethodName1, event.serverMethodName());
+
+            assertNull(event.serverSideData());
+            assertNull(event.sourceTag());
+            assertNull(event.sourceAttribute());
+
+            return result;
+        });
+
+        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+
+        final String customServerMethodName2 = "customServerMethod2";
+
+        browserPage.addServerMethod(customServerMethodName2, event -> {
+
+            assertNotNull(event);
+            assertEquals(data, event.data());
+            assertEquals(inputStream, event.inputStream());
+            assertEquals(outputStream, event.outputStream());
+            assertEquals(uri, event.uri());
+            assertEquals(customServerMethodName2, event.serverMethodName());
+            assertNull(event.serverSideData());
+
+            assertNull(event.sourceTag());
+            assertNull(event.sourceAttribute());
+
+            return result;
+        });
+
+        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+
+        browserPage.addServerMethod(customServerMethodName1, event -> {
+
+            assertNotNull(event);
+            assertEquals(data, event.data());
+            assertEquals(inputStream, event.inputStream());
+            assertEquals(outputStream, event.outputStream());
+            assertEquals(uri, event.uri());
+            assertEquals(customServerMethodName1, event.serverMethodName());
+            assertEquals(serverSideData, event.serverSideData());
+
+            assertNull(event.sourceTag());
+            assertNull(event.sourceAttribute());
+
+            return result;
+        }, serverSideData);
+
+        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+
     }
         
 

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
@@ -282,7 +282,6 @@ public class BrowserPageTest {
         }
 
         final WffBMObject result = new WffBMObject();
-        final WffBMObject data = new WffBMObject();
         final InputStream inputStream = new ByteArrayInputStream(new byte[0]);
         final OutputStream outputStream = new ByteArrayOutputStream();
         final String uri = "/user";

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
@@ -25,11 +25,13 @@ import java.lang.ref.Reference;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
+import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import com.webfirmframework.wffweb.tag.html.attribute.event.ServerMethod;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -275,6 +277,10 @@ public class BrowserPageTest {
             }
         };
 
+        record RecordData(InputStream inputStream, OutputStream outputStream) {
+
+        }
+
         final WffBMObject result = new WffBMObject();
         final WffBMObject data = new WffBMObject();
         final InputStream inputStream = new ByteArrayInputStream(new byte[0]);
@@ -282,38 +288,43 @@ public class BrowserPageTest {
         final String uri = "/user";
         final String customServerMethodName1 = "customServerMethod1";
         final Object serverSideData = new String("someserversidedata");
-        
+
+        final RecordData recordData = new RecordData(inputStream, outputStream);
+
         WffBMObject returnedResult = null;
 
         browserPage.addServerMethod(customServerMethodName1, event -> {
 
             assertNotNull(event);
-            assertEquals(data, event.data());
-            assertEquals(inputStream, event.inputStream());
-            assertEquals(outputStream, event.outputStream());
+
+            RecordData recordDataObj = (RecordData) event.recordData();
+            assertEquals(inputStream, recordDataObj.inputStream());
+            assertEquals(outputStream, recordDataObj.outputStream());
             assertEquals(uri, event.uri());
             assertEquals(customServerMethodName1, event.serverMethodName());
             assertEquals(serverSideData, event.serverSideData());
 
+            assertNull(event.data());
             assertNull(event.sourceTag());
             assertNull(event.sourceAttribute());
 
             return result;
         }, serverSideData);
 
-        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, recordData, uri);
         assertEquals(result, returnedResult);
 
         browserPage.addServerMethod(customServerMethodName1, event -> {
 
             assertNotNull(event);
-            assertEquals(data, event.data());
-            assertEquals(inputStream, event.inputStream());
-            assertEquals(outputStream, event.outputStream());
+            RecordData recordDataObj = (RecordData) event.recordData();
+            assertEquals(inputStream, recordDataObj.inputStream());
+            assertEquals(outputStream, recordDataObj.outputStream());
             assertEquals(uri, event.uri());
             assertEquals(customServerMethodName1, event.serverMethodName());
             assertEquals(customServerMethodName1, event.serverMethodName());
 
+            assertNull(event.data());
             assertNull(event.serverSideData());
             assertNull(event.sourceTag());
             assertNull(event.sourceAttribute());
@@ -321,7 +332,7 @@ public class BrowserPageTest {
             return result;
         });
 
-        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, recordData, uri);
         assertEquals(result, returnedResult);
 
         final String customServerMethodName2 = "customServerMethod2";
@@ -329,39 +340,41 @@ public class BrowserPageTest {
         browserPage.addServerMethod(customServerMethodName2, event -> {
 
             assertNotNull(event);
-            assertEquals(data, event.data());
-            assertEquals(inputStream, event.inputStream());
-            assertEquals(outputStream, event.outputStream());
+            RecordData recordDataObj = (RecordData) event.recordData();
+            assertEquals(inputStream, recordDataObj.inputStream());
+            assertEquals(outputStream, recordDataObj.outputStream());
             assertEquals(uri, event.uri());
             assertEquals(customServerMethodName2, event.serverMethodName());
             assertNull(event.serverSideData());
 
+            assertNull(event.data());
             assertNull(event.sourceTag());
             assertNull(event.sourceAttribute());
 
             return result;
         });
 
-        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, recordData, uri);
         assertEquals(result, returnedResult);
 
         browserPage.addServerMethod(customServerMethodName1, event -> {
 
             assertNotNull(event);
-            assertEquals(data, event.data());
-            assertEquals(inputStream, event.inputStream());
-            assertEquals(outputStream, event.outputStream());
+            RecordData recordDataObj = (RecordData) event.recordData();
+            assertEquals(inputStream, recordDataObj.inputStream());
+            assertEquals(outputStream, recordDataObj.outputStream());
             assertEquals(uri, event.uri());
             assertEquals(customServerMethodName1, event.serverMethodName());
             assertEquals(serverSideData, event.serverSideData());
 
+            assertNull(event.data());
             assertNull(event.sourceTag());
             assertNull(event.sourceAttribute());
 
             return result;
         }, serverSideData);
 
-        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, recordData, uri);
         assertEquals(result, returnedResult);
 
     }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/server/page/BrowserPageTest.java
@@ -282,6 +282,8 @@ public class BrowserPageTest {
         final String uri = "/user";
         final String customServerMethodName1 = "customServerMethod1";
         final Object serverSideData = new String("someserversidedata");
+        
+        WffBMObject returnedResult = null;
 
         browserPage.addServerMethod(customServerMethodName1, event -> {
 
@@ -299,7 +301,8 @@ public class BrowserPageTest {
             return result;
         }, serverSideData);
 
-        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        assertEquals(result, returnedResult);
 
         browserPage.addServerMethod(customServerMethodName1, event -> {
 
@@ -318,7 +321,8 @@ public class BrowserPageTest {
             return result;
         });
 
-        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        assertEquals(result, returnedResult);
 
         final String customServerMethodName2 = "customServerMethod2";
 
@@ -338,7 +342,8 @@ public class BrowserPageTest {
             return result;
         });
 
-        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        assertEquals(result, returnedResult);
 
         browserPage.addServerMethod(customServerMethodName1, event -> {
 
@@ -356,7 +361,8 @@ public class BrowserPageTest {
             return result;
         }, serverSideData);
 
-        browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        returnedResult = browserPage.invokeServerMethod(customServerMethodName1, data, uri, inputStream, outputStream);
+        assertEquals(result, returnedResult);
 
     }
         

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/repository/TagRepositoryTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/repository/TagRepositoryTest.java
@@ -50,7 +50,6 @@ import com.webfirmframework.wffweb.tag.html.tables.TBody;
 import com.webfirmframework.wffweb.tag.html.tables.Table;
 import com.webfirmframework.wffweb.tag.html.tables.Td;
 import com.webfirmframework.wffweb.tag.html.tables.Tr;
-import com.webfirmframework.wffweb.tag.htmlwff.Blank;
 import com.webfirmframework.wffweb.tag.htmlwff.NoTag;
 import com.webfirmframework.wffweb.tag.htmlwff.TagContent;
 import com.webfirmframework.wffweb.wffbm.data.BMValueType;
@@ -653,7 +652,7 @@ public class TagRepositoryTest {
         };
         browserPage.toHtmlString();
         TagRepository tagRepository = browserPage.getTagRepository();
-        tagRepository.upsert(new Blank(null, "test"), "somekey", new WffBMObject());
+        tagRepository.upsert(new NoTag(null, "test"), "somekey", new WffBMObject());
     }
     
     @Test (expected = InvalidTagException.class)
@@ -682,7 +681,7 @@ public class TagRepositoryTest {
         };
         browserPage.toHtmlString();
         TagRepository tagRepository = browserPage.getTagRepository();
-        tagRepository.upsert(new Blank(null, "test"), "somekey", new WffBMArray(BMValueType.STRING));
+        tagRepository.upsert(new NoTag(null, "test"), "somekey", new WffBMArray(BMValueType.STRING));
     }
     
     @Test (expected = InvalidTagException.class)
@@ -711,7 +710,7 @@ public class TagRepositoryTest {
         };
         browserPage.toHtmlString();
         TagRepository tagRepository = browserPage.getTagRepository();
-        tagRepository.delete(new Blank(null, "test"), "somekey");
+        tagRepository.delete(new NoTag(null, "test"), "somekey");
     }
     
     @Test
@@ -786,7 +785,7 @@ public class TagRepositoryTest {
         }}; 
         html.appendChild(new Div(null));
         
-        TagRepository.findOneTagAssignableToTag(Blank.class, html);
+        TagRepository.findOneTagAssignableToTag(NoTag.class, html);
     }
     
     @Test
@@ -860,7 +859,7 @@ public class TagRepositoryTest {
             }};
         }};
         
-        TagRepository.findTagsAssignableToTag(Blank.class, html);
+        TagRepository.findTagsAssignableToTag(NoTag.class, html);
     }
     
 


### PR DESCRIPTION
It contains the following changes:

- Minor thread-safety improvements related to whenURI feature.
- Multi-threading improvements related to virtual thread use.
- Removed unused code which was marked for removal.
- Removed all deprecated methods which were marked for removal.
- Implemented `getTempDirectory` method in `BrowserPage`.
- Client js security improvements made in the previous release is reverted.
- Implemented invokeServerMethod method in BrowserPage.
- NPE bug fix in `BrowserPageContext.INSTANCE.getBrowserPageIfValid(String)` method
