### PR TITLE
Enhancements for SharedTagContent and attribute classes

### DIFF
--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -147,7 +147,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.15.0</version>
+			<version>2.15.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/css/file/CssFile.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/css/file/CssFile.java
@@ -126,7 +126,7 @@ public abstract class CssFile implements Serializable, Cloneable {
                 if (optimizeCssString) {
                     for (final Entry<String, Set<AbstractCssFileBlock>> entry : selectorCssFileBlocks.entrySet()) {
                         final Set<AbstractCssFileBlock> cssFileBlocks = entry.getValue();
-                        if (cssFileBlocks.size() > 0) {
+                        if (!cssFileBlocks.isEmpty()) {
 
                             boolean exclude = true;
 
@@ -202,7 +202,7 @@ public abstract class CssFile implements Serializable, Cloneable {
                     final CssFile cssFile = (CssFile) field.get(this);
 
                     // adding empty set will remove all of the objects.
-                    if (cssFile.getCssBlocks().size() > 0) {
+                    if (!cssFile.getCssBlocks().isEmpty()) {
                         cssBlocks.addAll(cssFile.getCssBlocks());
                     }
                     field.setAccessible(accessible);
@@ -299,7 +299,7 @@ public abstract class CssFile implements Serializable, Cloneable {
         if (isOptimizeCssString()) {
             for (final Entry<String, Set<AbstractCssFileBlock>> entry : selectorCssFileBlocks.entrySet()) {
                 final Set<AbstractCssFileBlock> cssFileBlocks = entry.getValue();
-                if (cssFileBlocks.size() > 0) {
+                if (!cssFileBlocks.isEmpty()) {
 
                     boolean exclude = true;
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPage.java
@@ -1735,7 +1735,7 @@ public abstract class BrowserPage implements Serializable {
 
                 final Set<AbstractHtml> subChildren = child.getChildren(ACCESS_OBJECT);
 
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 
@@ -1811,7 +1811,7 @@ public abstract class BrowserPage implements Serializable {
 
                 final Set<AbstractHtml> subChildren = child.getChildren(ACCESS_OBJECT);
 
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
             }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPageContext.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/BrowserPageContext.java
@@ -19,7 +19,6 @@ import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayDeque;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -290,7 +289,7 @@ public enum BrowserPageContext {
 
         final BrowserPageSessionWrapper sessionWrapper = httpSessionIdSession.get(httpSessionId);
         if (sessionWrapper != null) {
-            return Collections.unmodifiableMap(sessionWrapper.browserPages);
+            return Map.copyOf(sessionWrapper.browserPages);
         }
         return null;
     }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/ChildTagAppendListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/ChildTagAppendListenerImpl.java
@@ -88,7 +88,7 @@ public final class ChildTagAppendListenerImpl implements ChildTagAppendListener 
                     }
 
                     final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
 
@@ -161,7 +161,7 @@ public final class ChildTagAppendListenerImpl implements ChildTagAppendListener 
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 
@@ -253,7 +253,7 @@ public final class ChildTagAppendListenerImpl implements ChildTagAppendListener 
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/ChildTagRemoveListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/ChildTagRemoveListenerImpl.java
@@ -78,7 +78,7 @@ public final class ChildTagRemoveListenerImpl implements ChildTagRemoveListener 
                     }
 
                     final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InnerHtmlAddListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InnerHtmlAddListenerImpl.java
@@ -89,7 +89,7 @@ public final class InnerHtmlAddListenerImpl implements InnerHtmlAddListener {
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InsertAfterListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InsertAfterListenerImpl.java
@@ -90,7 +90,7 @@ public final class InsertAfterListenerImpl implements InsertAfterListener {
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InsertBeforeListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InsertBeforeListenerImpl.java
@@ -90,7 +90,7 @@ public final class InsertBeforeListenerImpl implements InsertBeforeListener {
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InsertTagsBeforeListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/InsertTagsBeforeListenerImpl.java
@@ -90,7 +90,7 @@ public final class InsertTagsBeforeListenerImpl implements InsertTagsBeforeListe
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/LocalStorageImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/LocalStorageImpl.java
@@ -74,7 +74,7 @@ final class LocalStorageImpl implements LocalStorage {
         }
         ObjectUtil.requireNonNull(key, "key cannot be null");
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException("There is no active browser page in the session to set item");
         }
         final int id = itemIdGenerator.incrementAndGet();
@@ -96,7 +96,7 @@ final class LocalStorageImpl implements LocalStorage {
         ObjectUtil.requireNonNull(key, "key cannot be null");
         ObjectUtil.requireNonNull(consumer, "consumer cannot be null");
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException("There is no active browser page in the session to get item");
         }
         final int id = itemIdGenerator.incrementAndGet();
@@ -119,7 +119,7 @@ final class LocalStorageImpl implements LocalStorage {
         ObjectUtil.requireNonNull(key, "key cannot be null");
 
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException("There is no active browser page in the session to remove item");
         }
 
@@ -143,7 +143,7 @@ final class LocalStorageImpl implements LocalStorage {
         ObjectUtil.requireNonNull(key, "key cannot be null");
         ObjectUtil.requireNonNull(consumer, "consumer cannot be null");
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException(
                     "There is no active browser page in the session to remove and get item");
         }
@@ -175,7 +175,7 @@ final class LocalStorageImpl implements LocalStorage {
     @Override
     public void clear(final Consumer<Event> consumer) {
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException(
                     "There is no active browser page in the session to clear items and tokens");
         }
@@ -220,7 +220,7 @@ final class LocalStorageImpl implements LocalStorage {
     @Override
     public void clearItems(final Consumer<Event> consumer) {
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException("There is no active browser page in the session to clear items");
         }
         final int id = itemIdGenerator.incrementAndGet();
@@ -239,7 +239,7 @@ final class LocalStorageImpl implements LocalStorage {
     @Override
     public void clearTokens(final Consumer<Event> consumer) {
         final Collection<BrowserPage> bps = browserPages.values();
-        if (bps.size() == 0) {
+        if (bps.isEmpty()) {
             throw new BrowserPageNotFoundException("There is no active browser page in the session to clear tokens");
         }
         final int id = itemIdGenerator.incrementAndGet();
@@ -271,7 +271,7 @@ final class LocalStorageImpl implements LocalStorage {
                 final String localToken = tokenWrapper.getValue();
                 if (!value.equals(localToken)) {
                     final Collection<BrowserPage> bps = browserPages.values();
-                    if (bps.size() == 0) {
+                    if (bps.isEmpty()) {
                         throw new BrowserPageNotFoundException(
                                 "There is no active browser page in the session to remove the token");
                     }
@@ -294,7 +294,7 @@ final class LocalStorageImpl implements LocalStorage {
                 final long stamp = tokenWrapper.lock.writeLock();
                 try {
                     final Collection<BrowserPage> bps = browserPages.values();
-                    if (bps.size() == 0) {
+                    if (bps.isEmpty()) {
                         throw new BrowserPageNotFoundException(
                                 "There is no active browser page in the session to remove the token");
                     }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/ReplaceListenerImpl.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/server/page/ReplaceListenerImpl.java
@@ -90,7 +90,7 @@ public final class ReplaceListenerImpl implements ReplaceListener {
                 }
 
                 final Set<AbstractHtml> subChildren = child.getChildren(accessObject);
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -1258,6 +1258,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     final Iterator<AbstractHtml> iterator = children.iterator();
                     final AbstractHtml firstChild;
                     if (iterator.hasNext() && (firstChild = iterator.next()) != null) {
+                        @SuppressWarnings("rawtypes")
                         final SharedTagContent sharedTagContentLocal = firstChild.sharedTagContent;
                         if (firstChild instanceof NoTag && !firstChild.parentNullifiedOnce
                                 && sharedTagContentLocal != null) {
@@ -1373,6 +1374,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 final Iterator<AbstractHtml> iterator = children.iterator();
                 final AbstractHtml firstChild;
                 if (iterator.hasNext() && (firstChild = iterator.next()) != null) {
+                    @SuppressWarnings("rawtypes")
                     final SharedTagContent sharedTagContent = firstChild.sharedTagContent;
                     if (!firstChild.parentNullifiedOnce && sharedTagContent != null && firstChild instanceof NoTag) {
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -83,6 +83,7 @@ import com.webfirmframework.wffweb.tag.html.model.AbstractHtml5SharedObject;
 import com.webfirmframework.wffweb.tag.htmlwff.CustomTag;
 import com.webfirmframework.wffweb.tag.htmlwff.NoTag;
 import com.webfirmframework.wffweb.tag.repository.TagRepository;
+import com.webfirmframework.wffweb.util.StringUtil;
 import com.webfirmframework.wffweb.util.WffBinaryMessageUtil;
 import com.webfirmframework.wffweb.util.data.NameValue;
 import com.webfirmframework.wffweb.wffbm.data.WffBMArray;
@@ -135,6 +136,9 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
     private final StringBuilder htmlStartSB;
 
+    /**
+     * NB: it should never be nullified after initialization
+     */
     private volatile StringBuilder htmlMiddleSB;
 
 //    private StringBuilder htmlEndSB;
@@ -4393,9 +4397,12 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
     }
 
     /**
+     * Note: Only for internal use
+     *
      * @return the htmlMiddleSB
      * @author WFF
      * @since 1.0.0
+     *
      */
     protected StringBuilder getHtmlMiddleSB() {
         if (htmlMiddleSB == null) {
@@ -4409,6 +4416,43 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
             }
         }
         return htmlMiddleSB;
+    }
+
+    /**
+     * @return the string value of htmlMiddleSB or empty
+     * @since 12.0.0
+     */
+    protected String getHtmlMiddleString() {
+        final StringBuilder htmlMiddleSB = this.htmlMiddleSB;
+        if (htmlMiddleSB != null) {
+            final Lock lock = lockAndGetReadLock();
+            try {
+                return htmlMiddleSB.toString();
+            } finally {
+                lock.unlock();
+            }
+        }
+        return "";
+    }
+
+    /**
+     * @param child the string to be removed from htmlMiddleSB
+     * @since 12.0.0
+     */
+    protected void removeFromHtmlMiddleSB(final String child) {
+        final StringBuilder htmlMiddleSB = this.htmlMiddleSB;
+        if (htmlMiddleSB != null) {
+            final Lock lock = lockAndGetWriteLock();
+            try {
+                final String sb = htmlMiddleSB.toString();
+                final String replaced = StringUtil.replace(sb, child, "");
+                final int lastIndex = htmlMiddleSB.length() - 1;
+                htmlMiddleSB.delete(0, lastIndex);
+                htmlMiddleSB.append(replaced);
+            } finally {
+                lock.unlock();
+            }
+        }
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -2464,7 +2464,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         try {
             attributesMap = this.attributesMap;
             if (attributesMap != null) {
-                final Collection<AbstractAttribute> result = Collections.unmodifiableCollection(attributesMap.values());
+                final Collection<AbstractAttribute> result = List.copyOf(attributesMap.values());
                 return result;
             }
         } finally {
@@ -2483,7 +2483,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         final Map<String, AbstractAttribute> attributesMap = this.attributesMap;
 
         if (attributesMap != null) {
-            final Collection<AbstractAttribute> result = Collections.unmodifiableCollection(attributesMap.values());
+            final Collection<AbstractAttribute> result = List.copyOf(attributesMap.values());
             return result;
         }
         return null;
@@ -6323,7 +6323,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * @since 2.1.8
      */
     public Map<String, WffBMData> getWffObjects() {
-        return Collections.unmodifiableMap(wffBMDatas);
+        return Map.copyOf(wffBMDatas);
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -740,13 +740,12 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      */
     private void removeFromSharedTagContent(final AbstractHtml firstChild) {
         if (TagUtil.isTagless(firstChild) && !firstChild.parentNullifiedOnce) {
-            @SuppressWarnings("rawtypes")
-            final SharedTagContent sharedTagContent = firstChild.sharedTagContent;
+            final var sharedTagContent = firstChild.sharedTagContent;
             if (sharedTagContent != null && firstChild instanceof NoTag) {
                 firstChild.sharedTagContent = null;
                 firstChild.sharedTagContentSubscribed = null;
                 firstChild.cachedStcFormatter = null;
-                sharedTagContent.removeListenersLockless(internalId);
+                sharedTagContent.removeListeners(internalId);
             }
         }
     }
@@ -1256,8 +1255,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     final Iterator<AbstractHtml> iterator = children.iterator();
                     final AbstractHtml firstChild;
                     if (iterator.hasNext() && (firstChild = iterator.next()) != null) {
-                        @SuppressWarnings("rawtypes")
-                        final SharedTagContent sharedTagContentLocal = firstChild.sharedTagContent;
+                        final var sharedTagContentLocal = firstChild.sharedTagContent;
                         if (firstChild instanceof NoTag && !firstChild.parentNullifiedOnce
                                 && sharedTagContentLocal != null) {
                             firstChild.sharedTagContent = null;
@@ -1372,8 +1370,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 final Iterator<AbstractHtml> iterator = children.iterator();
                 final AbstractHtml firstChild;
                 if (iterator.hasNext() && (firstChild = iterator.next()) != null) {
-                    @SuppressWarnings("rawtypes")
-                    final SharedTagContent sharedTagContent = firstChild.sharedTagContent;
+                    final var sharedTagContent = firstChild.sharedTagContent;
                     if (!firstChild.parentNullifiedOnce && sharedTagContent != null && firstChild instanceof NoTag) {
 
                         firstChild.sharedTagContent = null;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -1253,6 +1253,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 final AbstractHtml noTagInserted = sharedTagContent.addInnerHtml(updateClient, this, formatter,
                         subscribe);
                 noTagInserted.sharedTagContent = sharedTagContent;
+                noTagInserted.sharedTagContentSubscribed = subscribe;
             } else {
                 if (children.size() == 1) {
                     final Iterator<AbstractHtml> iterator = children.iterator();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -2997,6 +2997,26 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * @since 12.0.0
      */
     protected String toInnerHtmlString() {
+        final Lock readLock = lockAndGetReadLock();
+        try {
+            final Set<AbstractHtml> children = this.children;
+            if (children.isEmpty()) {
+                return "";
+            }
+
+            final Iterator<AbstractHtml> iterator;
+            if (children.size() == 1 && (iterator = children.iterator()).hasNext()
+                    && iterator.next() instanceof final NoTag firstChild) {
+                final StringBuilder htmlMiddleSB = ((AbstractHtml) firstChild).htmlMiddleSB;
+                if (htmlMiddleSB != null) {
+                    return htmlMiddleSB.toString();
+                }
+                return "";
+            }
+        } finally {
+            readLock.unlock();
+        }
+
         // should be WriteLock as toHtmlStringLockless requires WriteLock
         final Lock lock = lockAndGetWriteLock();
         try {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -327,7 +327,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
             @Override
             public void clear() {
-                if (super.size() > 0) {
+                if (!super.isEmpty()) {
                     sharedObject.setChildModified(true, ACCESS_OBJECT);
                 }
                 super.clear();
@@ -1718,7 +1718,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     }
 
                     final Set<AbstractHtml> subChildren = child.children;
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
 
@@ -1787,7 +1787,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 child.removeDataWffId();
 
                 final Set<AbstractHtml> subChildren = child.children;
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 
@@ -1819,7 +1819,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     applicableTags.add(child);
                 } else {
                     final Set<AbstractHtml> subChildren = child.children;
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
                 }
@@ -1878,7 +1878,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
                 final Set<AbstractHtml> subChildren = eachChild.children;
 
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
 
@@ -1923,7 +1923,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                             updateClient);
                     if (innerHtmls != null && innerHtmls.length > 0) {
                         childrenStack.push(List.of(innerHtmls));
-                    } else if (eachChild.children != null && eachChild.children.size() > 0) {
+                    } else if (eachChild.children != null && !eachChild.children.isEmpty()) {
                         childrenStack.push(List.copyOf(eachChild.children));
                     }
                     if (eachChild.uriChangeContents != null) {
@@ -2609,7 +2609,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
             }
 
-            removed = removedAttributes.size() > 0;
+            removed = !removedAttributes.isEmpty();
 
             if (removed) {
                 this.attributes = attributesMap.values().toArray(new AbstractAttribute[attributesMap.size()]);
@@ -2757,7 +2757,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
             lock.unlock();
         }
 
-        if (attributesToRemove.size() == 0) {
+        if (attributesToRemove.isEmpty()) {
             return false;
         }
 
@@ -2785,7 +2785,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 }
             }
 
-            removed = removedAttributeNames.size() > 0;
+            removed = !removedAttributeNames.isEmpty();
 
             if (removed) {
                 attributes = attributesMap.values().toArray(new AbstractAttribute[attributesMap.size()]);
@@ -3001,7 +3001,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      * @since 2.1.12 proper implementation is available since 2.1.12
      */
     public void setChildren(final Set<AbstractHtml> children) {
-        if (children == null || children.size() == 0) {
+        if (children == null || children.isEmpty()) {
             removeAllChildren();
         } else {
             addInnerHtmls(children.toArray(new AbstractHtml[children.size()]));
@@ -3426,7 +3426,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      */
     private static void recurChildren(final StringBuilder tagBuilder, final Set<AbstractHtml> children,
             final boolean rebuild) {
-        if (children != null && children.size() > 0) {
+        if (children != null && !children.isEmpty()) {
             for (final AbstractHtml child : children) {
                 child.setRebuild(rebuild);
                 tagBuilder.append(child.getOpeningTag());
@@ -3858,7 +3858,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 bottomChild = child;
 
                 final Set<AbstractHtml> subChildren = child.children;
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     current = subChildren;
                 }
 
@@ -3896,7 +3896,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                 bottomChild = child;
 
                 final Set<AbstractHtml> subChildren = child.children;
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     current = subChildren;
                 }
             }
@@ -3986,7 +3986,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
             final OutputStream os, final Set<AbstractHtml> children, final boolean rebuild, final boolean flushOnWrite)
             throws IOException {
 
-        if (children != null && children.size() > 0) {
+        if (children != null && !children.isEmpty()) {
             for (final AbstractHtml child : children) {
                 child.setRebuild(rebuild);
 
@@ -4032,7 +4032,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
      */
     private void recurChildrenToWffBinaryMessageOutputStream(final Set<AbstractHtml> children, final boolean rebuild,
             final Charset charset) throws IOException {
-        if (children != null && children.size() > 0) {
+        if (children != null && !children.isEmpty()) {
             for (final AbstractHtml child : children) {
                 child.setRebuild(rebuild);
                 // wffBinaryMessageOutputStreamer
@@ -4610,7 +4610,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                     child.removeAttributes(excludeAttributes);
 
                     final Set<AbstractHtml> subChildren = child.children;
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
                 }
@@ -4713,7 +4713,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
                 final Set<AbstractHtml> subChildren = stackChild.children;
 
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     removedTagsStack.push(subChildren);
                 }
             }
@@ -4858,7 +4858,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
                     final Set<AbstractHtml> subChildren = tag.children;
 
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
 
@@ -4998,7 +4998,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
                     final Set<AbstractHtml> subChildren = tag.children;
 
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
 
@@ -5172,7 +5172,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
                     final Set<AbstractHtml> subChildren = tag.children;
 
-                    if (subChildren != null && subChildren.size() > 0) {
+                    if (subChildren != null && !subChildren.isEmpty()) {
                         childrenStack.push(subChildren);
                     }
 
@@ -6270,7 +6270,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
 
                 final Set<AbstractHtml> subChildren = eachChild.children;
 
-                if (subChildren != null && subChildren.size() > 0) {
+                if (subChildren != null && !subChildren.isEmpty()) {
                     childrenStack.push(subChildren);
                 }
             }
@@ -7308,7 +7308,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
                         final AbstractHtml[] innerHtmls = eachChild.changeInnerHtmlsForURIChange(uriEvent, true);
                         if (innerHtmls != null && innerHtmls.length > 0) {
                             childrenStack.push(List.of(innerHtmls));
-                        } else if (eachChild.children != null && eachChild.children.size() > 0) {
+                        } else if (eachChild.children != null && !eachChild.children.isEmpty()) {
                             childrenStack.push(List.copyOf(eachChild.children));
                         }
                         if (eachChild.uriChangeContents != null) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -1250,10 +1250,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         final Lock lock = lockAndGetWriteLock();
         try {
             if (sharedTagContent != null) {
-                final AbstractHtml noTagInserted = sharedTagContent.addInnerHtml(updateClient, this, formatter,
-                        subscribe);
-                noTagInserted.sharedTagContent = sharedTagContent;
-                noTagInserted.sharedTagContentSubscribed = subscribe;
+                sharedTagContent.addInnerHtml(updateClient, this, formatter, subscribe);
             } else {
                 if (children.size() == 1) {
                     final Iterator<AbstractHtml> iterator = children.iterator();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlRepository.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlRepository.java
@@ -140,7 +140,7 @@ public abstract class AbstractHtmlRepository {
     private static Collection<Lock> lockAndGetLocks(final boolean writeLock, final AbstractHtml... fromTags) {
 
         if (fromTags == null || fromTags.length == 0) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         List<TagContractRecord> tagContractRecords;
@@ -198,7 +198,7 @@ public abstract class AbstractHtmlRepository {
             final AbstractHtml... fromTags) {
 
         if (fromTags == null || fromTags.length == 0) {
-            return Collections.emptyList();
+            return List.of();
         }
 
         if (fromTags.length == 1) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/SharedTagContent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/SharedTagContent.java
@@ -1498,7 +1498,8 @@ public class SharedTagContent<T> {
 
                     // the condition isParentNullifiedOnce true means the parent
                     // of this tag has already been changed at least once
-                    if ((parentTag == null) || ((AbstractHtml) prevNoTag).isParentNullifiedOnce()) {
+                    if (parentTag == null || prevNoTagAsBase.isParentNullifiedOnce()
+                            || prevNoTagAsBase.sharedTagContent == null) {
                         prevNoTagAsBase.setCacheSTCFormatter(null);
                         prevNoTagAsBase.setSharedTagContent(null);
                         prevNoTagAsBase.setSharedTagContentSubscribed(null);
@@ -1516,8 +1517,6 @@ public class SharedTagContent<T> {
                         contentApplied = formatter.format(contentAfter);
                         if (contentApplied != null) {
                             prevNoTagAsBase.setCacheSTCFormatter(null);
-                            prevNoTagAsBase.setSharedTagContent(null);
-                            prevNoTagAsBase.setSharedTagContentSubscribed(null);
                             noTag = new NoTag(null, contentApplied.content, contentApplied.contentTypeHtml);
                         } else {
                             noTag = prevNoTag;
@@ -1525,8 +1524,6 @@ public class SharedTagContent<T> {
                     } catch (final Exception e) {
                         contentApplied = new Content<>("", false);
                         prevNoTagAsBase.setCacheSTCFormatter(null);
-                        prevNoTagAsBase.setSharedTagContent(null);
-                        prevNoTagAsBase.setSharedTagContentSubscribed(null);
                         noTag = new NoTag(null, contentApplied.content, contentApplied.contentTypeHtml);
                         LOGGER.log(Level.SEVERE, "Exception while ContentFormatter.format", e);
                     }
@@ -2014,6 +2011,10 @@ public class SharedTagContent<T> {
     private boolean removeForQ(final AbstractHtml insertedTag, final AbstractHtml parentTag) {
         final long stamp = lock.writeLock();
         try {
+            insertedTag.setCacheSTCFormatter(null);
+            insertedTag.setSharedTagContent(null);
+            insertedTag.setSharedTagContentSubscribed(null);
+
             final boolean removed = insertedTags.remove(insertedTag) != null;
             if (detachListeners != null) {
                 detachListeners.remove(parentTag.internalId());
@@ -2021,11 +2022,6 @@ public class SharedTagContent<T> {
             if (contentChangeListeners != null) {
                 contentChangeListeners.remove(parentTag.internalId());
             }
-
-            insertedTag.setSharedTagContent(null);
-            insertedTag.setSharedTagContentSubscribed(null);
-            insertedTag.setCacheSTCFormatter(null);
-
             return removed;
         } finally {
             lock.unlockWrite(stamp);
@@ -2149,11 +2145,12 @@ public class SharedTagContent<T> {
                 }
                 final InsertedTagData<T> insertedTagData = entry.getValue();
                 final AbstractHtml parentTag = prevNoTag.getParent();
+                final AbstractHtml prevNoTagAsBase = prevNoTag;
 
                 // the condition isParentNullifiedOnce true means the parent of
                 // this tag has already been changed at least once
-                if ((parentTag == null) || ((AbstractHtml) prevNoTag).isParentNullifiedOnce()) {
-                    final AbstractHtml prevNoTagAsBase = prevNoTag;
+                if (parentTag == null || prevNoTagAsBase.isParentNullifiedOnce()
+                        || prevNoTagAsBase.sharedTagContent == null) {
                     prevNoTagAsBase.setCacheSTCFormatter(null);
                     prevNoTagAsBase.setSharedTagContent(null);
                     prevNoTagAsBase.setSharedTagContentSubscribed(null);
@@ -2274,9 +2271,10 @@ public class SharedTagContent<T> {
                                     }
 
                                 } else {
+                                    previousNoTag.setCacheSTCFormatter(null);
                                     previousNoTag.setSharedTagContent(null);
                                     previousNoTag.setSharedTagContentSubscribed(null);
-                                    previousNoTag.setCacheSTCFormatter(null);
+
                                     final AbstractHtml noTagAsBase = parentNoTagData.getNoTag();
                                     noTagAsBase.setCacheSTCFormatter(null);
                                     noTagAsBase.setSharedTagContent(null);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Headers.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Headers.java
@@ -176,7 +176,7 @@ public class Headers extends AbstractValueSetAttribute implements ThAttributable
      *
      * @param force true to forcefully remove all values and also to update client
      *              even if it is already empty
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllHeaderIds(final boolean force) {
         super.removeAllFromAttributeValueSet(force);
@@ -186,7 +186,7 @@ public class Headers extends AbstractValueSetAttribute implements ThAttributable
      * sets the value for this attribute
      *
      * @param value the value for the attribute.
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void setValue(final String value) {
         super.setAttributeValue(value);
@@ -199,7 +199,7 @@ public class Headers extends AbstractValueSetAttribute implements ThAttributable
      *                       The default value is true but it will be ignored if
      *                       there is no client browser page.
      * @param attributeValue the value for the attribute.
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      * @author WFF
      */
     public void setValue(final boolean updateClient, final String attributeValue) {
@@ -212,7 +212,7 @@ public class Headers extends AbstractValueSetAttribute implements ThAttributable
      *              Sometimes we may modify the value only at client side (not
      *              server side), {@code setValue} will change only if the passed
      *              value is different from existing value at server side.
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void assignValue(final String value) {
         assignAttributeValue(value);
@@ -220,7 +220,7 @@ public class Headers extends AbstractValueSetAttribute implements ThAttributable
 
     /**
      * @return the header ids
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public Set<String> getHeaderIds() {
         return super.getCopyOfAttributeValueSet();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Headers.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Headers.java
@@ -18,6 +18,7 @@ package com.webfirmframework.wffweb.tag.html.attribute;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Set;
 
 import com.webfirmframework.wffweb.tag.html.attribute.core.AbstractValueSetAttribute;
 import com.webfirmframework.wffweb.tag.html.attribute.core.PreIndexedAttributeName;
@@ -210,14 +211,19 @@ public class Headers extends AbstractValueSetAttribute implements ThAttributable
      *              server side, the assigned value will be reflected in the UI.
      *              Sometimes we may modify the value only at client side (not
      *              server side), {@code setValue} will change only if the passed
-     *              value is different from existing value at server side. Note:
-     *              Currently, {@code setValue} doesn't check if the passed argument
-     *              is different from the existing value but it will be improved in
-     *              future so calling {@code assignValue} is similar to calling
-     *              {@code setValue}.
+     *              value is different from existing value at server side.
      * @since 12.0.0
      */
     public void assignValue(final String value) {
-        setValue(value);
+        assignAttributeValue(value);
     }
+
+    /**
+     * @return the header ids
+     * @since 12.0.0
+     */
+    public Set<String> getHeaderIds() {
+        return super.getCopyOfAttributeValueSet();
+    }
+
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Rel.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Rel.java
@@ -18,7 +18,6 @@ package com.webfirmframework.wffweb.tag.html.attribute;
 
 import java.io.Serial;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.webfirmframework.wffweb.tag.html.attribute.core.AbstractValueSetAttribute;
@@ -213,7 +212,7 @@ public class Rel extends AbstractValueSetAttribute implements AAttributable, Are
      * @author WFF
      */
     public Set<String> getValueSet() {
-        return new LinkedHashSet<>(super.getAttributeValueSet());
+        return super.getCopyOfAttributeValueSet();
     }
 
     /**
@@ -299,15 +298,11 @@ public class Rel extends AbstractValueSetAttribute implements AAttributable, Are
      *              server side, the assigned value will be reflected in the UI.
      *              Sometimes we may modify the value only at client side (not
      *              server side), {@code setValue} will change only if the passed
-     *              value is different from existing value at server side. Note:
-     *              Currently, {@code setValue} doesn't check if the passed argument
-     *              is different from the existing value but it will be improved in
-     *              future so calling {@code assignValue} is similar to calling
-     *              {@code setValue}.
+     *              value is different from existing value at server side.
      * @since 12.0.0-beta.7
      */
     public void assignValue(final String value) {
-        setValue(value);
+        assignAttributeValue(value);
     }
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Rel.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/Rel.java
@@ -240,7 +240,7 @@ public class Rel extends AbstractValueSetAttribute implements AAttributable, Are
     /**
      * removes the all values
      *
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllValues() {
         super.removeAllFromAttributeValueSet();
@@ -251,7 +251,7 @@ public class Rel extends AbstractValueSetAttribute implements AAttributable, Are
      *
      * @param force true to forcefully remove all values and also to update client
      *              even if it is already empty
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllValues(final boolean force) {
         super.removeAllFromAttributeValueSet(force);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -551,7 +551,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
 
     /**
      * @return the copy of attributeValueMap in thread-safe way
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     protected Map<String, String> getCopyOfAttributeValueMap() {
         final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
@@ -572,7 +572,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
     /**
      * @param key
      * @return the value
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     protected String getFromAttributeValueMap(final String key) {
         final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
@@ -1168,7 +1168,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
 
     /**
      * @return the attributeValueSet
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     protected Set<String> getAttributeValueSetNoInit() {
         return attributeValueSet;
@@ -1294,7 +1294,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      * @param force        true to force update client browser page
      * @param updateClient true to update client browser page
      * @param values       the values to add
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     protected void replaceAllInAttributeValueSet(final boolean force, final boolean updateClient,
             final Collection<String> values) {
@@ -1336,13 +1336,6 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
             }
 
         }
-    }
-
-    private boolean collectionsEquals(final Collection<String> values1, final Collection<String> values2) {
-        new ArrayList<>(values1);
-        new ArrayList<>(values2);
-
-        return new ArrayList<>(values1).equals(new ArrayList<>(values2));
     }
 
     /**
@@ -1467,7 +1460,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
     /**
      * clears all values from the value set.
      *
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     protected void removeAllFromAttributeValueSet(final boolean force) {
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -63,8 +63,14 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
 
     private volatile String attributeValue;
 
+    /**
+     * NB: it should never be nullified after initialization
+     */
     private volatile Map<String, String> attributeValueMap;
 
+    /**
+     * NB: it should never be nullified after initialization
+     */
     private volatile Set<String> attributeValueSet;
 
     private transient final Set<AbstractHtml> ownerTags;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -211,7 +211,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                 tagBuilder.append(new char[] { '=', '"' }).append(attributeValue);
                 result = StringBuilderUtil.getTrimmedString(tagBuilder) + '"';
                 tagBuilder.append('"');
-            } else if (attributeValueMap != null && attributeValueMap.size() > 0) {
+            } else if (attributeValueMap != null && !attributeValueMap.isEmpty()) {
                 tagBuilder.append(new char[] { '=', '"' });
                 final Set<Entry<String, String>> entrySet = getAttributeValueMap().entrySet();
                 for (final Entry<String, String> entry : entrySet) {
@@ -220,7 +220,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
 
                 result = StringBuilderUtil.getTrimmedString(tagBuilder) + '"';
                 tagBuilder.append('"');
-            } else if (attributeValueSet != null && attributeValueSet.size() > 0) {
+            } else if (attributeValueSet != null && !attributeValueSet.isEmpty()) {
                 tagBuilder.append(new char[] { '=', '"' });
                 for (final String each : getAttributeValueSet()) {
                     tagBuilder.append(each).append(' ');
@@ -270,7 +270,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
             result = StringBuilderUtil.getTrimmedString(attrBuilder);
         } else {
             final Map<String, String> attributeValueMap = this.attributeValueMap;
-            if (attributeValueMap != null && attributeValueMap.size() > 0) {
+            if (attributeValueMap != null && !attributeValueMap.isEmpty()) {
                 attrBuilder.append(new char[] { '=' });
                 final Set<Entry<String, String>> entrySet = getAttributeValueMap().entrySet();
                 for (final Entry<String, String> entry : entrySet) {
@@ -280,7 +280,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                 result = StringBuilderUtil.getTrimmedString(attrBuilder);
             } else {
                 final Set<String> attributeValueSet = this.attributeValueSet;
-                if (attributeValueSet != null && attributeValueSet.size() > 0) {
+                if (attributeValueSet != null && !attributeValueSet.isEmpty()) {
                     attrBuilder.append(new char[] { '=' });
                     for (final String each : getAttributeValueSet()) {
                         attrBuilder.append(each).append(' ');
@@ -392,7 +392,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
 
                 compressedBytesBuilder.write(attributeValue.getBytes(charset));
                 compressedBytes = compressedBytesBuilder.toByteArray();
-            } else if (attributeValueMap != null && attributeValueMap.size() > 0) {
+            } else if (attributeValueMap != null && !attributeValueMap.isEmpty()) {
 
                 if (attrNameIndexBytes == null) {
                     compressedBytesBuilder.write("=".getBytes(charset));
@@ -407,7 +407,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                     compressedBytesBuilder.write(new byte[] { ';' });
                 }
                 compressedBytes = compressedBytesBuilder.toByteArray();
-            } else if (attributeValueSet != null && attributeValueSet.size() > 0) {
+            } else if (attributeValueSet != null && !attributeValueSet.isEmpty()) {
 
                 if (attrNameIndexBytes == null) {
                     compressedBytesBuilder.write("=".getBytes(charset));
@@ -520,7 +520,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
             commonLock().lock();
             try {
                 if (attributeValueMap == null) {
-                    setAttributeValueMap(new LinkedHashMap<String, String>());
+                    setAttributeValueMap(new LinkedHashMap<>());
                 }
             } finally {
                 commonLock().unlock();
@@ -544,6 +544,46 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
     }
 
     /**
+     * @return the copy of attributeValueMap in thread-safe way
+     * @since 12.0.0
+     */
+    protected Map<String, String> getCopyOfAttributeValueMap() {
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Map<String, String> attributeValueMap = this.attributeValueMap;
+            if (attributeValueMap != null) {
+                return new LinkedHashMap<>(attributeValueMap);
+            }
+
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return Map.of();
+    }
+
+    /**
+     * @param key
+     * @return the value
+     * @since 12.0.0
+     */
+    protected String getFromAttributeValueMap(final String key) {
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Map<String, String> attributeValueMap = this.attributeValueMap;
+            if (attributeValueMap != null) {
+                return attributeValueMap.get(key);
+            }
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return null;
+    }
+
+    /**
      * adds the given key value.
      *
      * @param key
@@ -554,34 +594,33 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      */
     protected boolean addToAttributeValueMap(final String key, final String value) {
 
-        boolean listenerInvoked = false;
-
         final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
 
+        final Map<String, String> attributeValueMap = getAttributeValueMap();
+
+        final String previousValue = attributeValueMap.put(key, value);
+        final boolean proceed = !Objects.equals(previousValue, value);
         // should be after lockAndGetWriteLocks
-        final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
+        final OwnerTagsRecord ownerTagsRecord = proceed ? getOwnerTagsRecord() : null;
 
         try {
-            final Map<String, String> attributeValueMap = getAttributeValueMap();
 
-            final String previousValue = attributeValueMap.put(key, value);
-
-            if (!Objects.equals(previousValue, value)) {
+            if (proceed) {
                 setModifiedLockless(true);
                 invokeValueChangeListeners(ownerTagsRecord);
-                listenerInvoked = true;
             }
 
         } finally {
             for (final Lock lock : writeLocks) {
                 lock.unlock();
             }
-
         }
 
-        pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
+        if (proceed) {
+            pushQueues(ownerTagsRecord.sharedObjects, true);
+        }
 
-        return listenerInvoked;
+        return proceed;
     }
 
     /**
@@ -650,7 +689,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
         // considered as 1
         final Collection<AbstractHtml5SharedObject> sharedObjects = new LinkedHashSet<>(1);
 
-        final Set<AbstractHtml> ownerTags = Collections.unmodifiableSet(this.ownerTags);
+        final Set<AbstractHtml> ownerTags = Set.copyOf(this.ownerTags);
         for (final AbstractHtml ownerTag : ownerTags) {
             sharedObjects.add(ownerTag.getSharedObject());
         }
@@ -667,32 +706,82 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      */
     protected boolean addAllToAttributeValueMap(final Map<String, String> map) {
 
-        if (map != null && map.size() > 0) {
+        if (map != null && !map.isEmpty()) {
 
-            boolean listenerInvoked = false;
-
+            boolean modified = false;
             final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
 
             // should be after lockAndGetWriteLocks
             final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
+
             try {
 
-                getAttributeValueMap().putAll(map);
+                final Map<String, String> attributeValueMap = getAttributeValueMap();
 
-                setModifiedLockless(true);
+                for (final Entry<String, String> entry : map.entrySet()) {
+                    final String value = entry.getValue();
+                    modified |= !Objects.equals(attributeValueMap.put(entry.getKey(), value), value);
+                }
 
-                invokeValueChangeListeners(ownerTagsRecord);
-                listenerInvoked = true;
+                if (modified) {
+                    setModifiedLockless(true);
+                    invokeValueChangeListeners(ownerTagsRecord);
+                }
 
             } finally {
                 for (final Lock lock : writeLocks) {
                     lock.unlock();
                 }
-
             }
-            pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
-            return listenerInvoked;
+            pushQueues(ownerTagsRecord.sharedObjects, modified);
+            return true;
+        }
+        return false;
+    }
 
+    /**
+     * replaces in the attribute value map.
+     *
+     * @param map
+     * @param force
+     * @return true if it is modified
+     * @since 12.0.0
+     */
+    protected boolean replaceAllInAttributeValueMap(final Map<String, String> map, final boolean force) {
+
+        if (map != null) {
+            if (map.isEmpty()) {
+                return removeAllFromAttributeValueMap(force);
+            } else {
+                boolean modified = force;
+                final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
+
+                // should be after lockAndGetWriteLocks
+                final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
+
+                try {
+
+                    final Map<String, String> attributeValueMap = getAttributeValueMap();
+                    attributeValueMap.clear();
+
+                    for (final Entry<String, String> entry : map.entrySet()) {
+                        final String value = entry.getValue();
+                        modified |= !Objects.equals(attributeValueMap.put(entry.getKey(), value), value);
+                    }
+
+                    if (modified) {
+                        setModifiedLockless(true);
+                        invokeValueChangeListeners(ownerTagsRecord);
+                    }
+
+                } finally {
+                    for (final Lock lock : writeLocks) {
+                        lock.unlock();
+                    }
+                }
+                pushQueues(ownerTagsRecord.sharedObjects, modified);
+                return true;
+            }
         }
         return false;
     }
@@ -721,48 +810,48 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      */
     protected boolean removeFromAttributeValueMapByKeys(final String... keys) {
 
-        boolean listenerInvoked = false;
+        final Map<String, String> attributeValueMap = this.attributeValueMap;
+        if (attributeValueMap != null) {
+            boolean listenerInvoked = false;
+            final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
 
-        final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
+            // should be after lockAndGetWriteLocks
+            final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
 
-        // should be after lockAndGetWriteLocks
-        final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
-
-        boolean result = false;
-        try {
-
-            final Map<String, String> valueMap = getAttributeValueMap();
-
-            if (nullableAttrValueMapValue) {
-                for (final String key : keys) {
-                    result = valueMap.containsKey(key);
-                    if (result) {
-                        break;
+            boolean result = false;
+            try {
+                if (nullableAttrValueMapValue) {
+                    for (final String key : keys) {
+                        result = attributeValueMap.containsKey(key);
+                        if (result) {
+                            break;
+                        }
                     }
                 }
-            }
 
-            for (final String key : keys) {
-                final String previous = valueMap.remove(key);
-                if (previous != null) {
-                    result = true;
+                for (final String key : keys) {
+                    final String previous = attributeValueMap.remove(key);
+                    if (previous != null) {
+                        result = true;
+                    }
                 }
-            }
 
-            if (result) {
-                setModifiedLockless(true);
-                invokeValueChangeListeners(ownerTagsRecord);
-                listenerInvoked = true;
-            }
+                if (result) {
+                    setModifiedLockless(true);
+                    invokeValueChangeListeners(ownerTagsRecord);
+                    listenerInvoked = true;
+                }
 
-        } finally {
-            for (final Lock lock : writeLocks) {
-                lock.unlock();
-            }
+            } finally {
+                for (final Lock lock : writeLocks) {
+                    lock.unlock();
+                }
 
+            }
+            pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
+            return result;
         }
-        pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
-        return result;
+        return false;
     }
 
     /**
@@ -794,59 +883,58 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      */
     protected boolean removeFromAttributeValueMap(final String key, final String value) {
 
-        boolean listenerInvoked = false;
-
         final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
+        final boolean removed = getAttributeValueMap().remove(key, value);
 
         // should be after lockAndGetWriteLocks
-        final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
+        final OwnerTagsRecord ownerTagsRecord = removed ? getOwnerTagsRecord() : null;
         try {
-
-            final boolean removed = getAttributeValueMap().remove(key, value);
 
             if (removed) {
                 setModifiedLockless(true);
                 invokeValueChangeListeners(ownerTagsRecord);
-                listenerInvoked = true;
             }
 
         } finally {
             for (final Lock lock : writeLocks) {
                 lock.unlock();
             }
-
         }
-        pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
-        return listenerInvoked;
+        if (removed) {
+            pushQueues(ownerTagsRecord.sharedObjects, true);
+        }
+        return removed;
     }
 
     protected void removeAllFromAttributeValueMap() {
         removeAllFromAttributeValueMap(false);
     }
 
-    protected void removeAllFromAttributeValueMap(final boolean force) {
+    protected boolean removeAllFromAttributeValueMap(final boolean force) {
         final Map<String, String> attributeValueMap = this.attributeValueMap;
-        if (attributeValueMap != null && (force || attributeValueMap.size() > 0)) {
-
-            boolean listenerInvoked = false;
-
+        if (attributeValueMap != null) {
             final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
-
+            final boolean proceed = force || !attributeValueMap.isEmpty();
             // should be after lockAndGetWriteLocks
-            final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
-            try {
-                attributeValueMap.clear();
-                setModifiedLockless(true);
+            final OwnerTagsRecord ownerTagsRecord = proceed ? getOwnerTagsRecord() : null;
 
-                invokeValueChangeListeners(ownerTagsRecord);
-                listenerInvoked = true;
+            try {
+                if (proceed) {
+                    attributeValueMap.clear();
+                    setModifiedLockless(true);
+                    invokeValueChangeListeners(ownerTagsRecord);
+                }
             } finally {
                 for (final Lock lock : writeLocks) {
                     lock.unlock();
                 }
             }
-            pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
+            if (proceed) {
+                pushQueues(ownerTagsRecord.sharedObjects, true);
+            }
+            return proceed;
         }
+        return false;
     }
 
     /**
@@ -1073,13 +1161,20 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
     }
 
     /**
+     * @return the attributeValueSet
+     * @since 12.0.0
+     */
+    protected Set<String> getAttributeValueSetNoInit() {
+        return attributeValueSet;
+    }
+
+    /**
      * @param attributeValueSet the attributeValueSet to set
      * @author WFF
      * @since 1.0.0
-     * @deprecated use {@link #replaceAllInAttributeValueSet(Collection)} instead of
-     *             this method. This method is only for internal use.
+     * @deprecated This method is only for internal use.
      */
-    @Deprecated(forRemoval = false, since = "12.0.0-beta.7")
+    @Deprecated(forRemoval = true, since = "12.0.0-beta.7")
     protected void setAttributeValueSet(final Set<String> attributeValueSet) {
         if (!Objects.equals(this.attributeValueSet, attributeValueSet)) {
             final long stamp = ownerTagsLock.writeLock();
@@ -1179,42 +1274,69 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      * removes all and then adds all to the attribute value set.
      *
      * @param updateClient true to update client browser page
-     * @param values
+     * @param values       the values to add
      * @author WFF
      * @since 3.0.1
      */
     protected void replaceAllInAttributeValueSet(final boolean updateClient, final Collection<String> values) {
+        replaceAllInAttributeValueSet(false, updateClient, values);
+    }
+
+    /**
+     * removes all and then adds all to the attribute value set.
+     *
+     * @param force        true to force update client browser page
+     * @param updateClient true to update client browser page
+     * @param values       the values to add
+     * @since 12.0.0
+     */
+    protected void replaceAllInAttributeValueSet(final boolean force, final boolean updateClient,
+            final Collection<String> values) {
         if (values != null) {
+            if (values.isEmpty()) {
+                removeAllFromAttributeValueSet(force);
+            } else {
+                boolean listenerInvoked = false;
 
-            boolean listenerInvoked = false;
-
-            final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
-
-            // should be after lockAndGetWriteLocks
-            final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
-            try {
-
+                final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
                 final Set<String> attrValueSet = getAttributeValueSet();
-                attrValueSet.clear();
-                final boolean added = attrValueSet.addAll(values);
+                final boolean proceed = force || attrValueSet.isEmpty()
+                        || !List.copyOf(attrValueSet).equals(List.copyOf(values));
+                // should be after lockAndGetWriteLocks
+                final OwnerTagsRecord ownerTagsRecord = proceed ? getOwnerTagsRecord() : null;
+                try {
 
-                if (added) {
-                    setModifiedLockless(true);
-
-                    if (updateClient) {
-                        invokeValueChangeListeners(ownerTagsRecord);
-                        listenerInvoked = true;
+                    if (proceed) {
+                        attrValueSet.clear();
+                        final boolean added = attrValueSet.addAll(values);
+                        if (added) {
+                            setModifiedLockless(true);
+                            if (updateClient) {
+                                invokeValueChangeListeners(ownerTagsRecord);
+                                listenerInvoked = true;
+                            }
+                        }
                     }
-                }
 
-            } finally {
-                for (final Lock lock : writeLocks) {
-                    lock.unlock();
-                }
+                } finally {
+                    for (final Lock lock : writeLocks) {
+                        lock.unlock();
+                    }
 
+                }
+                if (proceed) {
+                    pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
+                }
             }
-            pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
+
         }
+    }
+
+    private boolean collectionsEquals(final Collection<String> values1, final Collection<String> values2) {
+        new ArrayList<>(values1);
+        new ArrayList<>(values2);
+
+        return new ArrayList<>(values1).equals(new ArrayList<>(values2));
     }
 
     /**
@@ -1345,29 +1467,26 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
 
         final Set<String> attributeValueSet = this.attributeValueSet;
 
-        if (attributeValueSet != null && (force || attributeValueSet.size() > 0)) {
-            boolean listenerInvoked = false;
-
+        if (attributeValueSet != null) {
             final Collection<Lock> writeLocks = lockAndGetWriteLocksWithAttrLock();
-
+            final boolean proceed = force || !attributeValueSet.isEmpty();
             // should be after lockAndGetWriteLocks
-            final OwnerTagsRecord ownerTagsRecord = getOwnerTagsRecord();
+            final OwnerTagsRecord ownerTagsRecord = proceed ? getOwnerTagsRecord() : null;
             try {
-
-                attributeValueSet.clear();
-                setModifiedLockless(true);
-
-                invokeValueChangeListeners(ownerTagsRecord);
-                listenerInvoked = true;
+                if (proceed) {
+                    attributeValueSet.clear();
+                    setModifiedLockless(true);
+                    invokeValueChangeListeners(ownerTagsRecord);
+                }
             } finally {
                 for (final Lock lock : writeLocks) {
                     lock.unlock();
                 }
-
             }
-            pushQueues(ownerTagsRecord.sharedObjects, listenerInvoked);
+            if (proceed) {
+                pushQueues(ownerTagsRecord.sharedObjects, true);
+            }
         }
-
     }
 
     /**
@@ -1438,7 +1557,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
      * @since 2.0.0
      */
     public Set<AttributeValueChangeListener> getValueChangeListeners() {
-        return Collections.unmodifiableSet(valueChangeListeners);
+        return Set.copyOf(valueChangeListeners);
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractValueSetAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractValueSetAttribute.java
@@ -18,6 +18,9 @@ package com.webfirmframework.wffweb.tag.html.attribute.core;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
 import com.webfirmframework.wffweb.util.StringUtil;
 
@@ -43,7 +46,11 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
     protected void setAttributeValue(final boolean updateClient, final String value) {
         if (value != null) {
             final Collection<String> allValues = extractValues(value);
-            super.replaceAllInAttributeValueSet(updateClient, allValues);
+            if (allValues.isEmpty()) {
+                super.removeAllFromAttributeValueSet();
+            } else {
+                super.replaceAllInAttributeValueSet(updateClient, allValues);
+            }
         }
     }
 
@@ -56,7 +63,10 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
         for (final String each : inputValues) {
             // As per Collections.addAll's doc it is faster than
             // allValues.addAll(Arrays.asList(values));
-            Collections.addAll(allValues, StringUtil.strip(each));
+            final String striped = StringUtil.strip(each);
+            if (!striped.isBlank()) {
+                Collections.addAll(allValues, striped);
+            }
         }
         return allValues;
     }
@@ -76,6 +86,32 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
         }
     }
 
+    @Override
+    protected void assignAttributeValue(final String value) {
+        if (value != null) {
+            replaceAllInAttributeValueSet(true, true, value);
+        }
+    }
+
+    /**
+     * @return the copy of attributeValueSet in thread-safe way
+     * @since 12.0.0
+     */
+    protected Set<String> getCopyOfAttributeValueSet() {
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Set<String> attributeValueSet = super.getAttributeValueSetNoInit();
+            if (attributeValueSet != null) {
+                return new LinkedHashSet<>(attributeValueSet);
+            }
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return Set.of();
+    }
+
     /**
      * Checks if the value is a part of this attribute value.
      *
@@ -86,7 +122,18 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
      * @author WFF
      */
     public boolean contains(final String value) {
-        return super.getAttributeValueSet().contains(value);
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Set<String> attributeValueSet = super.getAttributeValueSetNoInit();
+            if (attributeValueSet != null) {
+                return attributeValueSet.contains(value);
+            }
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return false;
     }
 
     /**
@@ -99,12 +146,73 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
      * @author WFF
      */
     public boolean containsAll(final Collection<String> values) {
-        return super.getAttributeValueSet().containsAll(values);
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Set<String> attributeValueSet = super.getAttributeValueSetNoInit();
+            if (attributeValueSet != null) {
+                return attributeValueSet.containsAll(values);
+            }
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return true if empty otherwise false
+     * @since 12.0.0
+     */
+    public boolean isEmpty() {
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Set<String> attributeValueSet = super.getAttributeValueSetNoInit();
+            if (attributeValueSet != null) {
+                return attributeValueSet.isEmpty();
+            }
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return the size
+     * @since 12.0.0
+     */
+    public int size() {
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Set<String> attributeValueSet = super.getAttributeValueSetNoInit();
+            if (attributeValueSet != null) {
+                return attributeValueSet.size();
+            }
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return 0;
     }
 
     @Override
     public String getAttributeValue() {
-        return StringUtil.join(' ', getAttributeValueSet());
+        final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
+        try {
+            final Set<String> attributeValueSet = super.getAttributeValueSetNoInit();
+            if (attributeValueSet != null) {
+                return StringUtil.join(' ', attributeValueSet);
+            }
+
+        } finally {
+            for (final Lock lock : readLocks) {
+                lock.unlock();
+            }
+        }
+        return "";
     }
 
     /**
@@ -149,16 +257,31 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
      * @since 3.0.1
      */
     protected void replaceAllInAttributeValueSet(final boolean updateClient, final String... attrValues) {
-        if (attrValues != null) {
+        replaceAllInAttributeValueSet(false, updateClient, attrValues);
+    }
 
+    /**
+     * Removes all values from the attributeValueSet and adds the given attribute
+     * values.
+     *
+     * @param force
+     * @param updateClient
+     * @param attrValues
+     * @since 12.0.0
+     */
+    private void replaceAllInAttributeValueSet(final boolean force, final boolean updateClient,
+            final String... attrValues) {
+        if (attrValues != null) {
             final Collection<String> allValues = new ArrayDeque<>();
             for (final String attrValue : attrValues) {
-                if (attrValue != null) {
-                    allValues.addAll(extractValues(attrValue));
+                if (attrValue != null && !attrValue.isBlank()) {
+                    final Collection<String> values = extractValues(attrValue);
+                    if (!values.isEmpty()) {
+                        allValues.addAll(values);
+                    }
                 }
             }
-
-            super.replaceAllInAttributeValueSet(updateClient, allValues);
+            super.replaceAllInAttributeValueSet(force, updateClient, allValues);
         }
     }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractValueSetAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractValueSetAttribute.java
@@ -86,6 +86,14 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
         }
     }
 
+    /**
+     * @param value the value to set again even if the existing value is same at
+     *              server side, the assigned value will be reflected in the UI.
+     *              Sometimes we may modify the value only at client side (not
+     *              server side), {@code setValue} will change only if the passed
+     *              value is different from existing value at server side.
+     * @since 12.0.0-beta.12
+     */
     @Override
     protected void assignAttributeValue(final String value) {
         if (value != null) {
@@ -95,7 +103,7 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
 
     /**
      * @return the copy of attributeValueSet in thread-safe way
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     protected Set<String> getCopyOfAttributeValueSet() {
         final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
@@ -162,7 +170,7 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
 
     /**
      * @return true if empty otherwise false
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public boolean isEmpty() {
         final Collection<Lock> readLocks = lockAndGetReadLocksWithAttrLock();
@@ -267,7 +275,7 @@ public abstract class AbstractValueSetAttribute extends AbstractAttribute {
      * @param force
      * @param updateClient
      * @param attrValues
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     private void replaceAllInAttributeValueSet(final boolean force, final boolean updateClient,
             final String... attrValues) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AttributeRegistry.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AttributeRegistry.java
@@ -438,7 +438,7 @@ public class AttributeRegistry {
         attributeClassByAttrName.put(AttributeNameConstants.USEMAP, UseMap.class);
         attributeClassByAttrName.put(AttributeNameConstants.NONCE, Nonce.class);
 
-        ATTRIBUTE_CLASS_BY_ATTR_NAME = Collections.unmodifiableMap(attributeClassByAttrName);
+        ATTRIBUTE_CLASS_BY_ATTR_NAME = Map.copyOf(attributeClassByAttrName);
 
         attributeClassByAttrNameTmp.putAll(attributeClassByAttrName);
 
@@ -460,7 +460,7 @@ public class AttributeRegistry {
         // in some machines multiple,selected comes as selected,multiple
         tmpSortedBooleanAttrNames.sort(Comparator.comparingInt(String::length).thenComparing(String::compareTo));
 
-        SORTED_BOOLEAN_ATTR_NAMES = Collections.unmodifiableList(tmpSortedBooleanAttrNames);
+        SORTED_BOOLEAN_ATTR_NAMES = List.copyOf(tmpSortedBooleanAttrNames);
 
         final List<String> tmpSortedEventAttrNames = new ArrayList<>(8);
 
@@ -494,7 +494,7 @@ public class AttributeRegistry {
             tmpSortedEventAttrNames.add(each.attrName());
         }
 
-        SORTED_EVENT_ATTR_NAMES = Collections.unmodifiableList(tmpSortedEventAttrNames);
+        SORTED_EVENT_ATTR_NAMES = List.copyOf(tmpSortedEventAttrNames);
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AttributeRegistry.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AttributeRegistry.java
@@ -610,7 +610,7 @@ public class AttributeRegistry {
                 }
             }
             attributeClassByAttrNameTmpLocal.clear();
-            if (unloadedClasses.size() > 0) {
+            if (!unloadedClasses.isEmpty()) {
                 attributeClassByAttrNameTmpLocal.putAll(unloadedClasses);
             } else {
                 attributeClassByAttrNameTmp = null;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/ClassAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/ClassAttribute.java
@@ -125,7 +125,7 @@ public class ClassAttribute extends AbstractValueSetAttribute implements GlobalA
     /**
      * removes all class names from the class attribute
      *
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllClassNames() {
         super.removeAllFromAttributeValueSet();
@@ -136,7 +136,7 @@ public class ClassAttribute extends AbstractValueSetAttribute implements GlobalA
      *
      * @param force true to forcefully remove all values and also to update client
      *              even if it is already empty
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllClassNames(final boolean force) {
         super.removeAllFromAttributeValueSet(force);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/ClassAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/ClassAttribute.java
@@ -17,7 +17,6 @@
 package com.webfirmframework.wffweb.tag.html.attribute.global;
 
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.webfirmframework.wffweb.tag.html.attribute.core.AbstractValueSetAttribute;
@@ -174,7 +173,7 @@ public class ClassAttribute extends AbstractValueSetAttribute implements GlobalA
      * @author WFF
      */
     public Set<String> getClassNames() {
-        return new LinkedHashSet<>(super.getAttributeValueSet());
+        return super.getCopyOfAttributeValueSet();
     }
 
     /**
@@ -198,15 +197,11 @@ public class ClassAttribute extends AbstractValueSetAttribute implements GlobalA
      *              server side, the assigned value will be reflected in the UI.
      *              Sometimes we may modify the value only at client side (not
      *              server side), {@code setValue} will change only if the passed
-     *              value is different from existing value at server side. Note:
-     *              Currently, {@code setValue} doesn't check if the passed argument
-     *              is different from the existing value but it will be improved in
-     *              future so calling {@code assignValue} is similar to calling
-     *              {@code setValue}.
+     *              value is different from existing value at server side.
      * @since 12.0.0-beta.7
      */
     public void assignValue(final String value) {
-        setValue(value);
+        assignAttributeValue(value);
     }
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/Style.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/Style.java
@@ -782,13 +782,33 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
     }
 
     /**
-     * adds the given css properties after removing all existing css properties
+     * replaces all existing css properties with the given css properties only if
+     * the given css properties are different from the existing.
      *
      * @param cssProperties styles separated by semicolon.<br>
      *                      eg :- {@code color:blue;text-align:center }
      *
      * @since 12.0.0
-     * @author WFF
+     */
+    public void setCssProperties(final String cssProperties) {
+        final long stamp = lock.writeLock();
+        try {
+            extractStylesAndAddToAttributeValueMap(cssProperties, true, false);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    /**
+     * replaces all existing css properties with the given css properties event if
+     * the given css properties are same as the existing. This method may be used to
+     * force to sync the given css properties with client browser page if the style
+     * property is changed at client side by custom JavaScript.
+     *
+     * @param cssProperties styles separated by semicolon.<br>
+     *                      eg :- {@code color:blue;text-align:center }
+     *
+     * @since 12.0.0
      */
     public void assignCssProperties(final String cssProperties) {
         final long stamp = lock.writeLock();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/Style.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/Style.java
@@ -788,7 +788,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
      * @param cssProperties styles separated by semicolon.<br>
      *                      eg :- {@code color:blue;text-align:center }
      *
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void setCssProperties(final String cssProperties) {
         final long stamp = lock.writeLock();
@@ -808,7 +808,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
      * @param cssProperties styles separated by semicolon.<br>
      *                      eg :- {@code color:blue;text-align:center }
      *
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void assignCssProperties(final String cssProperties) {
         final long stamp = lock.writeLock();
@@ -1246,7 +1246,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
      *
      * @param force true to forcefully remove all values and also to update client
      *              even if it is already empty
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllCssProperties(final boolean force) {
         final long stamp = lock.writeLock();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/Style.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/global/Style.java
@@ -22,7 +22,6 @@ import static com.webfirmframework.wffweb.css.CssConstants.IMPORTANT_UPPERCASE;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -671,7 +670,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
      *               eg :- {@code color:blue;text-align:center }
      */
     public Style(final String styles) {
-        extractStylesAndAddToAttributeValueMap(styles);
+        extractStylesAndAddToAttributeValueMap(styles, false, false);
     }
 
     /**
@@ -776,7 +775,25 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
     public void addCssProperties(final String cssProperties) {
         final long stamp = lock.writeLock();
         try {
-            extractStylesAndAddToAttributeValueMap(cssProperties);
+            extractStylesAndAddToAttributeValueMap(cssProperties, false, false);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    /**
+     * adds the given css properties after removing all existing css properties
+     *
+     * @param cssProperties styles separated by semicolon.<br>
+     *                      eg :- {@code color:blue;text-align:center }
+     *
+     * @since 12.0.0
+     * @author WFF
+     */
+    public void assignCssProperties(final String cssProperties) {
+        final long stamp = lock.writeLock();
+        try {
+            extractStylesAndAddToAttributeValueMap(cssProperties, true, true);
         } finally {
             lock.unlockWrite(stamp);
         }
@@ -889,14 +906,11 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
 
         if (important) {
             for (final CssProperty cssProperty : cssProperties) {
-
                 cssPropertiesToAdd.put(cssProperty.getCssName(), cssProperty.getCssValue() + " " + IMPORTANT);
             }
         } else {
             for (final CssProperty cssProperty : cssProperties) {
-
                 cssPropertiesToAdd.put(cssProperty.getCssName(), cssProperty.getCssValue());
-
             }
         }
 
@@ -1101,7 +1115,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
         final String strippedCssName = StringUtil.strip(cssName);
         final String strippedCssValue = StringUtil.strip(cssValue);
 
-        final String value = super.getAttributeValueMap().get(strippedCssName);
+        final String value = super.getFromAttributeValueMap(strippedCssName);
         // the value may contain !important that's why startsWith method is used
         // here.
 
@@ -1259,7 +1273,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
         try {
 
             final String trimmedStyleName = StringUtil.strip(styleName);
-            final String value = super.getAttributeValueMap().get(trimmedStyleName);
+            final String value = super.getFromAttributeValueMap(trimmedStyleName);
             if (value != null && !value.isEmpty()) {
                 return super.addToAttributeValueMap(trimmedStyleName, value + " " + IMPORTANT);
             }
@@ -1287,7 +1301,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
         try {
 
             final String trimmedStyleName = StringUtil.strip(styleName);
-            final String value = super.getAttributeValueMap().get(trimmedStyleName);
+            final String value = super.getFromAttributeValueMap(trimmedStyleName);
             if (value != null && !value.isEmpty()) {
                 return super.addToAttributeValueMap(trimmedStyleName,
                         StringUtil.strip(StringUtil.replace(value, IMPORTANT, "")));
@@ -1298,44 +1312,54 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
         }
     }
 
-    private void extractStylesAndAddToAttributeValueMap(final String styles) {
-        if (styles == null || StringUtil.isBlank(styles)) {
-            return;
-        }
-        final String[] stylesArray = StringUtil.splitBySemicolon(styles);
+    private void extractStylesAndAddToAttributeValueMap(final String styles, final boolean clearExisting,
+            final boolean force) {
+        final Map<String, String> cssPropertiesToAdd;
+        if (styles != null && !StringUtil.isBlank(styles)) {
+            final String[] stylesArray = StringUtil.splitBySemicolon(styles);
 
-        final Map<String, String> cssPropertiesToAdd = new LinkedHashMap<>(stylesArray.length);
+            cssPropertiesToAdd = new LinkedHashMap<>(stylesArray.length);
 
-        for (final String each : stylesArray) {
-            if (!StringUtil.isBlank(each)) {
-                final String[] styleNameValue = StringUtil.splitByColon(each);
-                if (styleNameValue.length == 2) {
+            for (final String each : stylesArray) {
+                if (!StringUtil.isBlank(each)) {
+                    final String[] styleNameValue = StringUtil.splitByColon(each);
+                    if (styleNameValue.length == 2) {
 
-                    final String cssName = StringUtil.strip(styleNameValue[0]);
-                    final String cssValue = StringUtil.strip(styleNameValue[1]);
-                    if (!cssName.isEmpty() && !cssValue.isEmpty()) {
+                        final String cssName = StringUtil.strip(styleNameValue[0]);
+                        final String cssValue = StringUtil.strip(styleNameValue[1]);
+                        if (!cssName.isEmpty() && !cssValue.isEmpty()) {
 
-                        cssPropertiesToAdd.put(cssName, cssValue);
+                            cssPropertiesToAdd.put(cssName, cssValue);
 
-                        // super.addToAttributeValueMap(cssName,
-                        // cssValue);
-                        // getCssPropertyLockless(cssName);
+                            // super.addToAttributeValueMap(cssName,
+                            // cssValue);
+                            // getCssPropertyLockless(cssName);
+                        }
+
+                    } else {
+                        LOGGER.warning(
+                                "\"" + styles + "\" contains invalid value or no value for any style name in it.");
                     }
-
-                } else {
-                    LOGGER.warning("\"" + styles + "\" contains invalid value or no value for any style name in it.");
                 }
             }
+        } else {
+            cssPropertiesToAdd = Map.of();
         }
 
-        if (cssPropertiesToAdd.size() > 0) {
-            super.addAllToAttributeValueMap(cssPropertiesToAdd);
-
-            for (final String cssName : cssPropertiesToAdd.keySet()) {
-                // to save the
-                // corresponding object to
-                // abstractCssPropertyClassObjects
-                getCssPropertyLockless(cssName);
+        if (clearExisting || !cssPropertiesToAdd.isEmpty()) {
+            final boolean modified = clearExisting ? super.replaceAllInAttributeValueMap(cssPropertiesToAdd, force)
+                    : super.addAllToAttributeValueMap(cssPropertiesToAdd);
+            if (modified) {
+                if (clearExisting) {
+                    cssProperties.clear();
+                    abstractCssPropertyClassObjects.clear();
+                }
+                for (final String cssName : cssPropertiesToAdd.keySet()) {
+                    // to save the
+                    // corresponding object to
+                    // abstractCssPropertyClassObjects
+                    getCssPropertyLockless(cssName);
+                }
             }
         }
     }
@@ -1368,7 +1392,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
 
         final long stamp = lock.readLock();
         try {
-            String value = super.getAttributeValueMap().get(cssProperty.getCssName());
+            String value = super.getFromAttributeValueMap(cssProperty.getCssName());
             if (value != null) {
                 value = value.toUpperCase();
                 return value.contains(cssProperty.getCssValue().toUpperCase()) && value.contains(IMPORTANT_UPPERCASE);
@@ -1395,7 +1419,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
         final long stamp = lock.readLock();
         try {
 
-            String value = super.getAttributeValueMap().get(styleName);
+            String value = super.getFromAttributeValueMap(styleName);
             if (value != null) {
                 value = value.toUpperCase();
                 return value.contains(IMPORTANT_UPPERCASE);
@@ -1454,7 +1478,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
 
         String value = null;
         // given priority for optimization rather than coding standard
-        if (classClass != null && classClass.isEnum() && (value = super.getAttributeValueMap().get(cssName)) != null) {
+        if (classClass != null && classClass.isEnum() && (value = super.getFromAttributeValueMap(cssName)) != null) {
 
             final String tempValue = StringUtil.strip(StringUtil
                     .replace(StringUtil.replace(TagStringUtil.toUpperCase(value), IMPORTANT_UPPERCASE, ""), "-", "_"));
@@ -1496,7 +1520,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
             }
 
             // given priority for optimization rather than coding standard.
-        } else if (classClass != null && (value = super.getAttributeValueMap().get(cssName)) != null) {
+        } else if (classClass != null && (value = super.getFromAttributeValueMap(cssName)) != null) {
 
             // .toLowerCase() is removed, it could become a bug
             // eg: font-family: "Times New Roman", Times, serif
@@ -1540,7 +1564,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
                     | InvocationTargetException | NoSuchMethodException | SecurityException e) {
                 LOGGER.severe(String.valueOf(e));
             }
-        } else if ((value = super.getAttributeValueMap().get(cssName)) != null) {
+        } else if ((value = super.getFromAttributeValueMap(cssName)) != null) {
             // .toLowerCase() is removed, it seems could become a bug
             // eg: another new property similar to
             // font-family: "Times New Roman", Times, serif
@@ -1576,7 +1600,7 @@ public class Style extends AbstractAttribute implements GlobalAttributable, Stat
     public Collection<CssProperty> getCssProperties() {
         final long stamp = lock.readLock();
         try {
-            return Collections.unmodifiableSet(cssProperties);
+            return Set.copyOf(cssProperties);
         } finally {
             lock.unlockRead(stamp);
         }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/core/TagRegistry.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/core/TagRegistry.java
@@ -308,7 +308,7 @@ public class TagRegistry {
         tagClassByTagName.put(TagNameConstants.PATH, Path.class);
         tagClassByTagName.put(TagNameConstants.TEXT, Text.class);
 
-        TAG_CLASS_BY_TAG_NAME = Collections.unmodifiableMap(tagClassByTagName);
+        TAG_CLASS_BY_TAG_NAME = Map.copyOf(tagClassByTagName);
 
         tagClassByTagNameTmp.putAll(tagClassByTagName);
 
@@ -318,7 +318,7 @@ public class TagRegistry {
             tagClassNameByTagName.put(entry.getKey(), entry.getValue().getSimpleName());
         }
 
-        TAG_CLASS_NAME_BY_TAG_NAME = Collections.unmodifiableMap(tagClassNameByTagName);
+        TAG_CLASS_NAME_BY_TAG_NAME = Map.copyOf(tagClassNameByTagName);
 
         TAG_NAMES_SET = ConcurrentHashMap.newKeySet(initialCapacity);
 
@@ -404,7 +404,7 @@ public class TagRegistry {
      * @since 3.0.2
      */
     public static Map<String, Class<?>> getTagClassByTagName() {
-        return Collections.unmodifiableMap(TAG_CLASS_BY_TAG_NAME);
+        return Map.copyOf(TAG_CLASS_BY_TAG_NAME);
     }
 
     /**

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/core/TagRegistry.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/core/TagRegistry.java
@@ -433,7 +433,7 @@ public class TagRegistry {
                 }
             }
             tagClassByTagNameTmpLocal.clear();
-            if (unloadedClasses.size() > 0) {
+            if (!unloadedClasses.isEmpty()) {
                 tagClassByTagNameTmpLocal.putAll(unloadedClasses);
             } else {
                 tagClassByTagNameTmp = null;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/formsandinputs/TextArea.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/formsandinputs/TextArea.java
@@ -119,7 +119,7 @@ public class TextArea extends AbstractHtml {
      */
     public String getChildText() {
         final List<AbstractHtml> children = getChildren();
-        if (children.size() > 0) {
+        if (!children.isEmpty()) {
             final StringBuilder builder = new StringBuilder();
             for (final AbstractHtml child : children) {
                 builder.append(child.toHtmlString());

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/formsandinputs/TextArea.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/formsandinputs/TextArea.java
@@ -15,7 +15,6 @@
  */
 package com.webfirmframework.wffweb.tag.html.formsandinputs;
 
-import java.util.List;
 import java.util.logging.Logger;
 
 import com.webfirmframework.wffweb.settings.WffConfiguration;
@@ -118,15 +117,7 @@ public class TextArea extends AbstractHtml {
      * @since 2.1.4
      */
     public String getChildText() {
-        final List<AbstractHtml> children = getChildren();
-        if (!children.isEmpty()) {
-            final StringBuilder builder = new StringBuilder();
-            for (final AbstractHtml child : children) {
-                builder.append(child.toHtmlString());
-            }
-            return builder.toString();
-        }
-        return "";
+        return super.toInnerHtmlString();
     }
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/html5/attribute/AutoComplete.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/html5/attribute/AutoComplete.java
@@ -361,7 +361,7 @@ public class AutoComplete extends AbstractValueSetAttribute implements InputAttr
     /**
      * removes the all values
      *
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllValues() {
         super.removeAllFromAttributeValueSet();
@@ -372,7 +372,7 @@ public class AutoComplete extends AbstractValueSetAttribute implements InputAttr
      *
      * @param force true to forcefully remove all values and also to update client
      *              even if it is already empty
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public void removeAllValues(final boolean force) {
         super.removeAllFromAttributeValueSet(force);
@@ -458,7 +458,7 @@ public class AutoComplete extends AbstractValueSetAttribute implements InputAttr
      *              Sometimes we may modify the value only at client side (not
      *              server side), {@code setValue} will change only if the passed
      *              value is different from existing value at server side.
-     * @since 12.0.0-beta.7
+     * @since 12.0.0-beta.12
      */
     public void assignValue(final String value) {
         assignAttributeValue(value);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/html5/attribute/AutoComplete.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/html5/attribute/AutoComplete.java
@@ -17,7 +17,6 @@
 package com.webfirmframework.wffweb.tag.html.html5.attribute;
 
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.webfirmframework.wffweb.tag.html.attribute.core.AbstractValueSetAttribute;
@@ -441,7 +440,7 @@ public class AutoComplete extends AbstractValueSetAttribute implements InputAttr
      * @author WFF
      */
     public Set<String> getValueSet() {
-        return new LinkedHashSet<>(super.getAttributeValueSet());
+        return super.getCopyOfAttributeValueSet();
     }
 
     /**
@@ -458,15 +457,11 @@ public class AutoComplete extends AbstractValueSetAttribute implements InputAttr
      *              server side, the assigned value will be reflected in the UI.
      *              Sometimes we may modify the value only at client side (not
      *              server side), {@code setValue} will change only if the passed
-     *              value is different from existing value at server side. Note:
-     *              Currently, {@code setValue} doesn't check if the passed argument
-     *              is different from the existing value but it will be improved in
-     *              future so calling {@code assignValue} is similar to calling
-     *              {@code setValue}.
+     *              value is different from existing value at server side.
      * @since 12.0.0-beta.7
      */
     public void assignValue(final String value) {
-        setValue(value);
+        assignAttributeValue(value);
     }
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/NoTag.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/NoTag.java
@@ -31,7 +31,6 @@ import com.webfirmframework.wffweb.tag.html.SharedTagContent;
 import com.webfirmframework.wffweb.tag.html.SharedTagContent.ContentFormatter;
 import com.webfirmframework.wffweb.tag.html.TagEvent;
 import com.webfirmframework.wffweb.tag.html.URIStateSwitch;
-import com.webfirmframework.wffweb.util.StringUtil;
 
 /**
  * It's a tag which makes child content without any opening closing tag. <br>
@@ -163,12 +162,7 @@ public class NoTag extends AbstractHtml {
      * @author WFF
      */
     public void removeChild(final String child) {
-        final StringBuilder htmlMiddleSB = getHtmlMiddleSB();
-        final String sb = htmlMiddleSB.toString();
-        final String replaced = StringUtil.replace(sb, child, "");
-        final int lastIndex = htmlMiddleSB.length() - 1;
-        htmlMiddleSB.delete(0, lastIndex);
-        htmlMiddleSB.append(replaced);
+        super.removeFromHtmlMiddleSB(child);
     }
 
     /**
@@ -190,7 +184,7 @@ public class NoTag extends AbstractHtml {
      * @author WFF
      */
     public String getChildContent() {
-        return getHtmlMiddleSB().toString();
+        return super.getHtmlMiddleString();
     }
 
     /**
@@ -252,6 +246,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier) {
@@ -261,6 +256,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final int index) {
@@ -270,6 +266,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Supplier<AbstractHtml[]> failTagsSupplier) {
@@ -279,6 +276,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Supplier<AbstractHtml[]> failTagsSupplier,
@@ -289,6 +287,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Consumer<TagEvent> failConsumer,
@@ -299,6 +298,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate,
             final Supplier<AbstractHtml[]> successTagsSupplier, final Consumer<TagEvent> failConsumer) {
@@ -308,6 +308,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Supplier<AbstractHtml[]> failTagsSupplier, final int index) {
@@ -317,6 +318,7 @@ public class NoTag extends AbstractHtml {
     /**
      * @deprecated this method is not allowed in NoTag or Blank class.
      */
+    @Override
     @Deprecated(since = "12.0.0-beta.1")
     public URIStateSwitch whenURI(final Predicate<URIEvent> uriEventPredicate, final Consumer<TagEvent> successConsumer,
             final Supplier<AbstractHtml[]> failTagsSupplier) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/TagContent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/htmlwff/TagContent.java
@@ -66,7 +66,7 @@ public enum TagContent {
      *                type
      * @param content the content to be added
      * @return parent
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public static <R extends AbstractHtml> R textIfRequired(final R parent, final String content) {
         if (parent.getFirstChild() instanceof final NoTag noTag) {
@@ -130,7 +130,7 @@ public enum TagContent {
      *                type
      * @param content the content to be added
      * @return parent
-     * @since 12.0.0
+     * @since 12.0.0-beta.12
      */
     public static <R extends AbstractHtml> R htmlIfRequired(final R parent, final String content) {
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/util/CssValueUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/util/CssValueUtil.java
@@ -120,7 +120,7 @@ public final class CssValueUtil {
                 }
             }
 
-            if (startAndEndIndexes.size() == 0) {
+            if (startAndEndIndexes.isEmpty()) {
                 return Arrays.asList(StringUtil.splitBySpace(StringUtil.convertWhitespacesToSingleSpace(cssValue)));
             }
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/util/FileUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/util/FileUtil.java
@@ -65,7 +65,7 @@ public final class FileUtil {
                         if (Files.isDirectory(each)) {
                             try (Stream<Path> pathsOfEach = Files.list(each)) {
                                 final List<Path> paths = pathsOfEach.toList();
-                                if (paths.size() > 0) {
+                                if (!paths.isEmpty()) {
                                     for (final Path path : paths) {
                                         q.addFirst(path);
                                     }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlTest.java
@@ -3003,4 +3003,18 @@ public class AbstractHtmlTest {
         assertTrue(div.getSharedObject().isWhenURIUsed());
     }
 
+    @Test()
+    public void testGetChildrenSize() {
+        Div parentDiv = new Div(null, new Id("parentDivId"));
+        Div childDiv1 = new Div(parentDiv, new Id("child1"));
+        Div childDiv2 = new Div(parentDiv, new Id("child2"));
+        assertEquals(2, parentDiv.getChildrenSize());
+        assertEquals(0, childDiv1.getChildrenSize());
+        assertEquals(0, childDiv2.getChildrenSize());
+
+        assertTrue(parentDiv.hasChildren());
+        assertFalse(childDiv1.hasChildren());
+        assertFalse(childDiv2.hasChildren());
+    }
+
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attribute/global/StyleTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attribute/global/StyleTest.java
@@ -88,6 +88,18 @@ public class StyleTest {
          fail("Not yet implemented");
     }
     
+    @Test
+    public void testAddCssProperties() {
+        final Style style = new Style();
+        style.addCssProperties(true, AlignContent.CENTER);
+        assertEquals("style=\"align-content:center !important;\"", style.toHtmlString());
+        style.assignCssProperties("color:blue;text-align:center");
+        
+        assertEquals("style=\"color:blue;text-align:center;\"", style.toHtmlString());
+        style.addCssProperties("align-content:center !important;");
+        assertEquals("style=\"color:blue;text-align:center;align-content:center !important;\"", style.toHtmlString());
+    }
+    
   @Test
   public void testAddCssPropertiesImportantCssProperties() {
       final Style style = new Style();

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attribute/global/StyleTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attribute/global/StyleTest.java
@@ -89,7 +89,7 @@ public class StyleTest {
     }
     
     @Test
-    public void testAddCssProperties() {
+    public void testAssignCssProperties() {
         final Style style = new Style();
         style.addCssProperties(true, AlignContent.CENTER);
         assertEquals("style=\"align-content:center !important;\"", style.toHtmlString());
@@ -99,7 +99,19 @@ public class StyleTest {
         style.addCssProperties("align-content:center !important;");
         assertEquals("style=\"color:blue;text-align:center;align-content:center !important;\"", style.toHtmlString());
     }
-    
+
+    @Test
+    public void testSetCssProperties() {
+        final Style style = new Style();
+        style.addCssProperties(true, AlignContent.CENTER);
+        assertEquals("style=\"align-content:center !important;\"", style.toHtmlString());
+        style.setCssProperties("color:blue;text-align:center");
+
+        assertEquals("style=\"color:blue;text-align:center;\"", style.toHtmlString());
+        style.addCssProperties("align-content:center !important;");
+        assertEquals("style=\"color:blue;text-align:center;align-content:center !important;\"", style.toHtmlString());
+    }
+
   @Test
   public void testAddCssPropertiesImportantCssProperties() {
       final Style style = new Style();

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attribute/global/StyleTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/tag/html/attribute/global/StyleTest.java
@@ -98,6 +98,9 @@ public class StyleTest {
         assertEquals("style=\"color:blue;text-align:center;\"", style.toHtmlString());
         style.addCssProperties("align-content:center !important;");
         assertEquals("style=\"color:blue;text-align:center;align-content:center !important;\"", style.toHtmlString());
+        
+        style.assignCssProperties("");
+        assertEquals("style", style.toHtmlString());
     }
 
     @Test
@@ -110,6 +113,9 @@ public class StyleTest {
         assertEquals("style=\"color:blue;text-align:center;\"", style.toHtmlString());
         style.addCssProperties("align-content:center !important;");
         assertEquals("style=\"color:blue;text-align:center;align-content:center !important;\"", style.toHtmlString());
+        
+        style.setCssProperties("");
+        assertEquals("style", style.toHtmlString());
     }
 
   @Test


### PR DESCRIPTION
- New feature methods `SharedTagContent` 
- Major thread-safety improvements for `SharedTagContent` to be compatible it with whenURI feature (to avoid deadlock)
- Data consistency improvements for `SharedTagContent`
- Thread-safety improvements for attribute classes
- New methods for attribute classes
- Optimizations and code syntax improvements

### New feature methods

#### New methods in `SharedTagContent`

- `hasPendingTask`
- `pendingTasksSize`
- `setAsyncUpdate`
- `isAsyncUpdate`
- `getContentWithType`

#### New methods in `AutoComplete`

- `removeAllValues`
-  `assignValue`

#### New methods in `ClassAttribute`

- `removeAllClassNames`

#### New methods in `Headers`
- `removeAllHeaderIds`
- `setValue`
- `assignValue`

#### New methods in `Rel`

- `removeAllValues`

#### New methods in `Style`

 - `setCssProperties`
 - `assignCssProperties`
 - `removeAllCssProperties`

#### New methods in `TagContent`

- `textIfRequired`
- `htmlIfRequired`

The javadoc contains the working of these methods.
