### PR TITLE
wffweb-12.0.5 release changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://img.shields.io/badge/build-passing-greensvg?style=flat)](https://app.circleci.com/pipelines/github/webfirmframework/wff?branch=master&filter=all)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/410601e16dc54b0a973c03845ad790c2)](https://www.codacy.com/app/webfirm-framework/wff?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=webfirmframework/wff&amp;utm_campaign=Badge_Grade)
 [![Stackoverflow](https://img.shields.io/badge/stackoverflow-wffweb-orange.svg)](https://stackoverflow.com/questions/tagged/wffweb)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.webfirmframework/wffweb/badge.svg)](https://search.maven.org/#artifactdetails%7Ccom.webfirmframework%7Cwffweb%7C12.0.4%7Cjar)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.webfirmframework/wffweb/badge.svg)](https://search.maven.org/#artifactdetails%7Ccom.webfirmframework%7Cwffweb%7C12.0.5%7Cjar)
 [![javadoc](https://javadoc.io/badge2/com.webfirmframework/wffweb/javadoc.svg)](https://javadoc.io/doc/com.webfirmframework/wffweb)
 [![GitHub license](https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat)](https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -147,13 +147,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.18.3</version>
+			<version>2.19.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>de.undercouch</groupId>
 			<artifactId>bson4jackson</artifactId>
-			<version>2.15.1</version>
+			<version>2.18.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.1.1-SNAPSHOT</version>
+	<version>12.1.2-SNAPSHOT</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.1.2-SNAPSHOT</version>
+	<version>12.0.5</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -76,13 +76,13 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.13.0</version>
+						<version>3.14.0</version>
 					</plugin>
 
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-install-plugin</artifactId>
-						<version>3.1.3</version>
+						<version>3.1.4</version>
 					</plugin>
 
 					<plugin>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.0.4</version>
+	<version>12.1.1-SNAPSHOT</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtml.java
@@ -7182,6 +7182,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         do {
             if (lock != null) {
                 lock.unlock();
+                Thread.onSpinWait();
             }
             currentSO = sharedObject;
             lock = currentSO.getLock(ACCESS_OBJECT).writeLock();
@@ -7210,6 +7211,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         do {
             if (lock != null) {
                 lock.unlock();
+                Thread.onSpinWait();
             }
             currentSO = sharedObject;
             if (latestSharedObject != null && latestSharedObject.objectId().compareTo(currentSO.objectId()) > 0) {
@@ -7252,6 +7254,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         do {
             if (lock != null) {
                 lock.unlock();
+                Thread.onSpinWait();
             }
             currentSO = sharedObject;
             lock = currentSO.getLock(ACCESS_OBJECT).readLock();
@@ -7279,6 +7282,7 @@ public abstract non-sealed class AbstractHtml extends AbstractJsObject implement
         do {
             if (lock != null) {
                 lock.unlock();
+                Thread.onSpinWait();
             }
             currentSO = sharedObject;
             if (latestSharedObject != null && latestSharedObject.objectId().compareTo(currentSO.objectId()) > 0) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlRepository.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/AbstractHtmlRepository.java
@@ -160,6 +160,7 @@ public abstract class AbstractHtmlRepository {
                 for (final Lock lock : locks) {
                     lock.unlock();
                 }
+                Thread.onSpinWait();
             }
 
             tagContractRecords = new ArrayList<>(fromTags.length);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/SharedTagContent.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/SharedTagContent.java
@@ -1420,7 +1420,7 @@ public class SharedTagContent<T> {
 
         if (shared) {
 
-            final List<AbstractHtml5SharedObject> sharedObjects = new ArrayList<>(4);
+            final Queue<AbstractHtml5SharedObject> sharedObjects = new ConcurrentLinkedQueue<>();
             Deque<Runnable> runnables = null;
             final long stamp = lock.writeLock();
             try {
@@ -1771,10 +1771,11 @@ public class SharedTagContent<T> {
      * @since 3.0.15 introduced executor
      */
     private void pushQueue(final Executor executor, final UpdateClientNature updateClientNature,
-            final List<AbstractHtml5SharedObject> sharedObjects) {
+            final Queue<AbstractHtml5SharedObject> sharedObjects) {
 
         final List<PushQueue> pushQueues = new ArrayList<>(sharedObjects.size());
-        for (final AbstractHtml5SharedObject sharedObject : sharedObjects) {
+        AbstractHtml5SharedObject sharedObject;
+        while ((sharedObject = sharedObjects.poll()) != null) {
             final PushQueue pushQueue = sharedObject.getPushQueue(ACCESS_OBJECT);
             if (pushQueue != null) {
                 pushQueues.add(pushQueue);
@@ -2122,7 +2123,7 @@ public class SharedTagContent<T> {
             final Set<AbstractHtml> exclusionClientUpdateTags, final boolean parallelUpdateOnTags,
             final boolean calledByThread) {
 
-        final List<AbstractHtml5SharedObject> sharedObjects = new ArrayList<>(4);
+        final Queue<AbstractHtml5SharedObject> sharedObjects = new ConcurrentLinkedQueue<>();
         Deque<Runnable> runnables = null;
 
         final long stamp = lock.writeLock();

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/TagUtil.java
@@ -182,6 +182,7 @@ public final class TagUtil {
                 for (final Lock lock : locks) {
                     lock.unlock();
                 }
+                Thread.onSpinWait();
             }
 
             tagContractRecords = new ArrayList<>(foreignTags.length + 1);

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/tag/html/attribute/core/AbstractAttribute.java
@@ -1725,6 +1725,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                 for (final Lock lock : writeLocks) {
                     lock.unlock();
                 }
+                Thread.onSpinWait();
             }
 
             tagContractRecords = new ArrayList<>(capacity);
@@ -1800,6 +1801,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                     for (final Lock lock : writeLocks) {
                         lock.unlock();
                     }
+                    Thread.onSpinWait();
                 }
 
                 tagContractRecords = new ArrayList<>(capacity);
@@ -1875,6 +1877,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                 for (final Lock lock : readLocks) {
                     lock.unlock();
                 }
+                Thread.onSpinWait();
             }
 
             tagContractRecords = new ArrayList<>(capacity);
@@ -1949,6 +1952,7 @@ public abstract non-sealed class AbstractAttribute extends AbstractTagBase {
                     for (final Lock lock : readLocks) {
                         lock.unlock();
                     }
+                    Thread.onSpinWait();
                 }
 
                 tagContractRecords = new ArrayList<>(capacity);


### PR DESCRIPTION
# Release Changes

## Major bug fixes
A major thread-safety bug fix in `SharedTagContent` reported in #97. 

The bug is it throws `NullPointerException` while calling `setContent`/`detach` method  if async update is enabled. To workaround this issue, disable async update by `setAsyncUpdate` method. By default, it is disabled.

## Major improvements
JVM related improvements to prevent CPU overheating in a special multi-threading scenario.