### PR TITLE
wffweb-12.0.11 release changes

### DIFF
--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.0.10</version>
+	<version>12.1.5-SNAPSHOT</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -76,7 +76,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
-						<version>3.14.1</version>
+						<version>3.15.0</version>
 					</plugin>
 
 					<plugin>

--- a/wffweb/pom.xml
+++ b/wffweb/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.webfirmframework</groupId>
 	<artifactId>wffweb</artifactId>
-	<version>12.1.5-SNAPSHOT</version>
+	<version>12.0.11</version>
 
 	<properties>
 		<maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/TriConsumer.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/TriConsumer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright since 2014 Web Firm Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webfirmframework.wffweb;
+
+/**
+ * @param <T> the first argument type.
+ * @param <U> the second argument type.
+ * @param <V> the third argument type.
+ * @since 12.0.11
+ */
+@FunctionalInterface
+public interface TriConsumer<T, U, V> {
+
+    void accept(T t, U u, V v);
+
+}

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/css/UnicodeRange.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/css/UnicodeRange.java
@@ -82,7 +82,7 @@ public class UnicodeRange extends AbstractCssProperty<UnicodeRange> {
 
     /**
      * @param unicodeChars
-     * @return Defines the range of unicode characters the font supports. Default
+     * @return Defines the range of Unicode characters the font supports. Default
      *         value is "U+0-10FFFF"
      * @author WFF
      * @since 1.1.2

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/js/JsUtil.java
@@ -321,7 +321,7 @@ public final class JsUtil {
      * @param codePoints
      * @return the striped codePoints
      * @since 3.0.1 initial implementation.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      */
     private static int[] strip(final int[] codePoints) {
 
@@ -370,7 +370,7 @@ public final class JsUtil {
     @Deprecated(forRemoval = true, since = "12.0.0-beta.5")
     static String toDynamicJs(final String s) {
 
-        final int[] codePoints = strip(s.codePoints().toArray());
+        final int[] codePoints = strip(StringUtil.toCodePoints(s));
 
         final StringBuilder builder = new StringBuilder(codePoints.length);
 
@@ -406,7 +406,7 @@ public final class JsUtil {
     /**
      * It replaces all new lines by {@code \n} so that it can be used as a dynamic
      * JavaScript string variable value in js function body of event attributes. It
-     * is unicode aware.
+     * is Unicode aware.
      *
      * @param s
      * @return the string having all lines replaced by {@code \n} .
@@ -414,7 +414,7 @@ public final class JsUtil {
      */
     public static String toDynamicJsString(final String s) {
 
-        final int[] codePoints = s.codePoints().toArray();
+        final int[] codePoints = StringUtil.toCodePoints(s);
 
         final StringBuilder builder = new StringBuilder(codePoints.length);
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonBooleanValueType.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonBooleanValueType.java
@@ -36,9 +36,11 @@ public enum JsonBooleanValueType {
         }
     };
 
-    private static final int[] TRUE_CODE_POINTS = "true".codePoints().toArray();
+    //    private static final int[] TRUE_CODE_POINTS = "true".codePoints().toArray();
+    private static final int[] TRUE_CODE_POINTS = {116, 114, 117, 101};
 
-    private static final int[] FALSE_CODE_POINTS = "false".codePoints().toArray();
+    //    private static final int[] FALSE_CODE_POINTS = "false".codePoints().toArray();
+    private static final int[] FALSE_CODE_POINTS = {102, 97, 108, 115, 101};
 
     JsonBooleanValueType() {
     }
@@ -58,8 +60,8 @@ public enum JsonBooleanValueType {
         return Arrays.equals(JsonBooleanValueType.TRUE_CODE_POINTS, 0, JsonBooleanValueType.TRUE_CODE_POINTS.length,
                 jsonCodePoints, startEndIndices[0], (startEndIndices[1] + 1))
                 || Arrays.equals(JsonBooleanValueType.FALSE_CODE_POINTS, 0,
-                        JsonBooleanValueType.FALSE_CODE_POINTS.length, jsonCodePoints, startEndIndices[0],
-                        (startEndIndices[1] + 1));
+                JsonBooleanValueType.FALSE_CODE_POINTS.length, jsonCodePoints, startEndIndices[0],
+                (startEndIndices[1] + 1));
     }
 
     static Boolean parseBooleanOtherwiseNull(final int[] jsonCodePoints, final int[] startEndIndices) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonCodePointUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonCodePointUtil.java
@@ -22,56 +22,58 @@ package com.webfirmframework.wffweb.json;
  */
 final class JsonCodePointUtil {
 
-    private static final int[] LONG_MIN_VALUE_CODE_POINTS = String.valueOf(Long.MIN_VALUE).codePoints().toArray();
+    //    private static final int[] LONG_MIN_VALUE_CODE_POINTS = String.valueOf(Long.MIN_VALUE).codePoints().toArray();
+    private static final int[] LONG_MIN_VALUE_CODE_POINTS = {45, 57, 50, 50, 51, 51, 55, 50, 48, 51, 54, 56, 53, 52, 55, 55, 53, 56, 48, 56};
 
-    private static final int[] LONG_MAX_VALUE_CODE_POINTS = String.valueOf(Long.MAX_VALUE).codePoints().toArray();
+    //    private static final int[] LONG_MAX_VALUE_CODE_POINTS = String.valueOf(Long.MAX_VALUE).codePoints().toArray();
+    private static final int[] LONG_MAX_VALUE_CODE_POINTS = {57, 50, 50, 51, 51, 55, 50, 48, 51, 54, 56, 53, 52, 55, 55, 53, 56, 48, 55};
 
-//    private static final int MINUS_CODE_POINT = "-".codePointAt(0);
+    //    private static final int MINUS_CODE_POINT = "-".codePointAt(0);
     private static final int MINUS_CODE_POINT = 45;
 
     // static final int E_UPPER_CASE_CODE_POINT = "E".codePointAt(0);
     private static final int E_UPPER_CASE_CODE_POINT = 69;
 
-//    static final int E_LOWER_CASE_CODE_POINT = "e".codePointAt(0);
+    //    static final int E_LOWER_CASE_CODE_POINT = "e".codePointAt(0);
     private static final int E_LOWER_CASE_CODE_POINT = 101;
 
-//    static final int ESCAPE_CODE_POINT = "\\".codePointAt(0);
+    //    static final int ESCAPE_CODE_POINT = "\\".codePointAt(0);
     static final int ESCAPE_CODE_POINT = 92;
 
-//    static final int DOUBLE_QUOTES_CODE_POINT = "\"".codePointAt(0);
+    //    static final int DOUBLE_QUOTES_CODE_POINT = "\"".codePointAt(0);
     static final int DOUBLE_QUOTES_CODE_POINT = 34;
 
-//    private static final int SPACE_CODE_POINT = " ".codePointAt(0);
+    //    private static final int SPACE_CODE_POINT = " ".codePointAt(0);
     private static final int SPACE_CODE_POINT = 32;
 
-//    static final int SLASH_N_CODE_POINT = "\n".codePointAt(0);
+    //    static final int SLASH_N_CODE_POINT = "\n".codePointAt(0);
     static final int SLASH_N_CODE_POINT = 10;
 
-//    static final int SLASH_R_CODE_POINT = "\r".codePointAt(0);
+    //    static final int SLASH_R_CODE_POINT = "\r".codePointAt(0);
     static final int SLASH_R_CODE_POINT = 13;
 
-//    static final int SLASH_T_CODE_POINT = "\t".codePointAt(0);
+    //    static final int SLASH_T_CODE_POINT = "\t".codePointAt(0);
     static final int SLASH_T_CODE_POINT = 9;
 
-//    static final int U_CODE_POINT = "u".codePointAt(0);
+    //    static final int U_CODE_POINT = "u".codePointAt(0);
     static final int U_CODE_POINT = 117;
 
-//    private static final int ZERO_CODE_POINT = "0".codePointAt(0);
+    //    private static final int ZERO_CODE_POINT = "0".codePointAt(0);
     private static final int ZERO_CODE_POINT = 48;
 
-//    private static final int NINE_CODE_POINT = "9".codePointAt(0);
+    //    private static final int NINE_CODE_POINT = "9".codePointAt(0);
     private static final int NINE_CODE_POINT = 57;
 
-//    private static final int A_UPPER_CASE_CODE_POINT = "A".codePointAt(0);
+    //    private static final int A_UPPER_CASE_CODE_POINT = "A".codePointAt(0);
     private static final int A_UPPER_CASE_CODE_POINT = 65;
 
-//    private static final int A_LOWER_CASE_CODE_POINT = "a".codePointAt(0);
+    //    private static final int A_LOWER_CASE_CODE_POINT = "a".codePointAt(0);
     private static final int A_LOWER_CASE_CODE_POINT = 97;
 
-//    private static final int F_UPPER_CASE_CODE_POINT = "F".codePointAt(0);
+    //    private static final int F_UPPER_CASE_CODE_POINT = "F".codePointAt(0);
     private static final int F_UPPER_CASE_CODE_POINT = 70;
 
-//    private static final int F_LOWER_CASE_CODE_POINT = "f".codePointAt(0);
+    //    private static final int F_LOWER_CASE_CODE_POINT = "f".codePointAt(0);
     private static final int F_LOWER_CASE_CODE_POINT = 102;
 
     // Note: it should be sorted in ascending order, call
@@ -115,7 +117,7 @@ final class JsonCodePointUtil {
     static int[][] splitByAnyOld(final int[] codePoints, final int delim) {
         // TODO remove this method later
         if (codePoints.length == 0) {
-            return new int[][] { codePoints };
+            return new int[][]{codePoints};
         }
 
         int[] delimPositionInit = new int[codePoints.length];
@@ -148,7 +150,7 @@ final class JsonCodePointUtil {
         }
 
         if (delimCount == 0) {
-            return new int[][] { codePoints };
+            return new int[][]{codePoints};
         }
 
         final int[] delimPositionsFinal = new int[delimCount];
@@ -214,12 +216,12 @@ final class JsonCodePointUtil {
      * @since 12.0.4
      */
     static int[][] splitByAnyRangeBound(final int[] codePoints, final int startIndex, final int endIndex,
-            final int delim) {
+                                        final int delim) {
         if (startIndex > endIndex) {
-            return new int[][] { new int[0] };
+            return new int[][]{new int[0]};
         }
         if (startIndex == endIndex && codePoints[startIndex] == delim) {
-            return new int[][] { new int[0], new int[0] };
+            return new int[][]{new int[0], new int[0]};
         }
         final int length = endIndex - startIndex + 1;
         final int[] delimPositionInit = new int[length];
@@ -250,7 +252,7 @@ final class JsonCodePointUtil {
         if (delimCount == 0) {
             final int[] part = new int[length];
             System.arraycopy(codePoints, startIndex, part, 0, part.length);
-            return new int[][] { part };
+            return new int[][]{part};
         }
 
         final int[][] splitCodePoints = new int[delimCount + 1][];
@@ -296,8 +298,8 @@ final class JsonCodePointUtil {
             return false;
         }
         return switch (c) {
-        case SPACE_CODE_POINT, SLASH_N_CODE_POINT, SLASH_T_CODE_POINT, SLASH_R_CODE_POINT -> true;
-        default -> Character.isWhitespace(c);
+            case SPACE_CODE_POINT, SLASH_N_CODE_POINT, SLASH_T_CODE_POINT, SLASH_R_CODE_POINT -> true;
+            default -> Character.isWhitespace(c);
         };
     }
 
@@ -354,7 +356,7 @@ final class JsonCodePointUtil {
                 break;
             }
         }
-        return new int[] { first, last };
+        return new int[]{first, last};
     }
 
     static int[] cut(final int[] codePoints, final int[] startEndIndices) {
@@ -376,17 +378,17 @@ final class JsonCodePointUtil {
         if (startEndIndices != null) {
             for (int i = startEndIndices[0]; i < startEndIndices[1]; i++) {
                 switch (codePoints[i]) {
-                case E_LOWER_CASE_CODE_POINT, E_UPPER_CASE_CODE_POINT -> {
-                    return true;
-                }
+                    case E_LOWER_CASE_CODE_POINT, E_UPPER_CASE_CODE_POINT -> {
+                        return true;
+                    }
                 }
             }
         }
         for (final int codePoint : codePoints) {
             switch (codePoint) {
-            case E_LOWER_CASE_CODE_POINT, E_UPPER_CASE_CODE_POINT -> {
-                return true;
-            }
+                case E_LOWER_CASE_CODE_POINT, E_UPPER_CASE_CODE_POINT -> {
+                    return true;
+                }
             }
         }
         return false;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonConcurrentSkipListMap.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonConcurrentSkipListMap.java
@@ -17,14 +17,16 @@ package com.webfirmframework.wffweb.json;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /**
  * To parse json object string:
  *
  * <pre><code>
- * JsonMapNode jsonMap = JsonConcurrentMap.parse("""
+ * JsonMapNode jsonMap = JsonConcurrentSkipListMap.parse("""
  *             {
  *             "key" : "value",
  *             "key1" : "value1"
@@ -41,45 +43,41 @@ import java.util.concurrent.ConcurrentHashMap;
  * System.out.println("jsonString = " + jsonString); // jsonString = {"key1":"value1","key":"value"}
  * </code></pre>
  *
- * @since 12.0.4
+ * @since 12.0.11
  */
-public non-sealed class JsonConcurrentMap extends ConcurrentHashMap<String, Object>
+public non-sealed class JsonConcurrentSkipListMap extends ConcurrentSkipListMap<String, Object>
         implements JsonMapNode, Serializable {
 
     @Serial
     private static final long serialVersionUID = 1L;
 
     private static final JsonParser JSON_PARSER = JsonParser.newBuilder()
-            .jsonObjectType(JsonObjectType.JSON_CONCURRENT_MAP).jsonArrayType(JsonArrayType.JSON_LINKED_LIST)
+            .jsonObjectType(JsonObjectType.JSON_CONCURRENT_SKIP_LIST_MAP).jsonArrayType(JsonArrayType.JSON_LINKED_LIST)
             .validateEscapeSequence(true).build();
 
-    public JsonConcurrentMap() {
+    public JsonConcurrentSkipListMap() {
         super();
     }
 
-    public JsonConcurrentMap(final int initialCapacity) {
-        super(initialCapacity);
+    public JsonConcurrentSkipListMap(final Comparator<? super String> comparator) {
+        super(comparator);
     }
 
-    public JsonConcurrentMap(final Map<? extends String, ?> m) {
+    public JsonConcurrentSkipListMap(final Map<? extends String, ?> m) {
         super(m);
     }
 
-    public JsonConcurrentMap(final int initialCapacity, final float loadFactor) {
-        super(initialCapacity, loadFactor);
-    }
-
-    public JsonConcurrentMap(final int initialCapacity, final float loadFactor, final int concurrencyLevel) {
-        super(initialCapacity, loadFactor, concurrencyLevel);
+    public JsonConcurrentSkipListMap(final SortedMap<String, ?> m) {
+        super(m);
     }
 
     /**
      * @param json the json string to parse
-     * @return the JsonConcurrentMap object which is equivalent to JSON object.
-     * @since 12.0.4
+     * @return the JsonConcurrentSkipListMap object which is equivalent to JSON object.
+     * @since 12.0.11
      */
-    public static JsonConcurrentMap parse(final String json) {
-        if (JSON_PARSER.parseJsonObject(json) instanceof final JsonConcurrentMap jsonMap) {
+    public static JsonConcurrentSkipListMap parse(final String json) {
+        if (JSON_PARSER.parseJsonObject(json) instanceof final JsonConcurrentSkipListMap jsonMap) {
             return jsonMap;
         }
         return null;

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonListNode.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonListNode.java
@@ -15,23 +15,27 @@
  */
 package com.webfirmframework.wffweb.json;
 
+import com.webfirmframework.wffweb.InvalidValueException;
+import com.webfirmframework.wffweb.TriConsumer;
+import com.webfirmframework.wffweb.util.StringUtil;
+import com.webfirmframework.wffweb.wffbm.data.BMValueType;
+import com.webfirmframework.wffweb.wffbm.data.WffBMArray;
+import com.webfirmframework.wffweb.wffbm.data.WffBMNumberArray;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import com.webfirmframework.wffweb.InvalidValueException;
-import com.webfirmframework.wffweb.wffbm.data.BMValueType;
-import com.webfirmframework.wffweb.wffbm.data.WffBMArray;
-import com.webfirmframework.wffweb.wffbm.data.WffBMNumberArray;
 
 /**
  * @since 12.0.4
  */
-public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits JsonList, JsonLinkedList {
+public sealed interface JsonListNode extends JsonBaseNode, List<Object> permits JsonList, JsonLinkedList {
 
     /**
      * @param index the index to get value.
@@ -46,13 +50,60 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
         if (o instanceof final String s) {
             return s;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return JsonValueType.ENCODED_STRING.equals(jsonValue.valueType()) ? jsonValue.asString(true) : jsonValue.asString(false);
+        }
+        return o.toString();
+    }
+
+    /**
+     * @param index                      the index to get value.
+     * @param decodeUnicodeCharsSequence true to decode the Unicode chars sequences like <span>\</span><span>u2122</span> to Java chars or false to use as it is.
+     * @return the string value or null.
+     * @since 12.0.11
+     */
+    default String getValueAsString(final int index, final boolean decodeUnicodeCharsSequence) {
+        final Object o = get(index);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof final String s) {
+            if (decodeUnicodeCharsSequence) {
+                final int[] codePoints = StringUtil.toCodePoints(s);
+                return JsonStringUtil.toUnicodeCharsDecodedString(codePoints, 0, codePoints.length);
+            }
+            return s;
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return JsonValueType.ENCODED_STRING.equals(jsonValue.valueType()) ? jsonValue.asString(true, decodeUnicodeCharsSequence) : jsonValue.asString(false, decodeUnicodeCharsSequence);
+        }
         return o.toString();
     }
 
     /**
      * @param index the index to get value.
+     * @return the Boolean value or null. It will throw exception if the value is
+     * not parsable to Boolean.
+     * @since 12.0.11
+     */
+    default Boolean getValueAsBoolean(final int index) {
+        final Object o = get(index);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof final Boolean i) {
+            return i;
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asBoolean();
+        }
+        return Boolean.valueOf(o.toString());
+    }
+
+    /**
+     * @param index the index to get value.
      * @return the Integer value or null. It will throw exception if the value is
-     *         not parsable to integer.
+     * not parsable to integer.
      * @since 12.0.4
      */
     default Integer getValueAsInteger(final int index) {
@@ -63,13 +114,16 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
         if (o instanceof final Integer i) {
             return i;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asInteger();
+        }
         return Integer.valueOf(o.toString());
     }
 
     /**
      * @param index the index to get value.
      * @return the Long value or null. It will throw exception if the value is not
-     *         parsable to Long.
+     * parsable to Long.
      * @since 12.0.4
      */
     default Long getValueAsLong(final int index) {
@@ -80,13 +134,16 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
         if (o instanceof final Long l) {
             return l;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asLong();
+        }
         return Long.valueOf(o.toString());
     }
 
     /**
      * @param index the index to get value.
      * @return the Double value or null. It will throw exception if the value is not
-     *         parsable to Double.
+     * parsable to Double.
      * @since 12.0.4
      */
     default Double getValueAsDouble(final int index) {
@@ -94,8 +151,11 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
         if (o == null) {
             return null;
         }
-        if (o instanceof final Double d) {
-            return d;
+        if (o instanceof final Double l) {
+            return l;
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asDouble();
         }
         return Double.valueOf(o.toString());
     }
@@ -103,7 +163,7 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
     /**
      * @param index the index to get value.
      * @return the BigInteger value or null. It will throw exception if the value is
-     *         not parsable to BigInteger.
+     * not parsable to BigInteger.
      * @since 12.0.4
      */
     default BigInteger getValueAsBigInteger(final int index) {
@@ -114,13 +174,16 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
         if (o instanceof final BigInteger bi) {
             return bi;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asBigInteger();
+        }
         return new BigInteger(o.toString());
     }
 
     /**
      * @param index the index to get value.
      * @return the BigDecimal value or null. It will throw exception if the value is
-     *         not parsable to BigDecimal.
+     * not parsable to BigDecimal.
      * @since 12.0.4
      */
     default BigDecimal getValueAsBigDecimal(final int index) {
@@ -131,13 +194,58 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
         if (o instanceof final BigDecimal bd) {
             return bd;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asBigDecimal();
+        }
         return new BigDecimal(o.toString());
     }
 
     /**
      * @param index the index to get value.
+     * @return the value as JsonValue object.
+     * @throws InvalidValueException if the value is not suitable to create an object of JsonValue.
+     * @since 12.0.11
+     */
+    default JsonValue getValueAsJsonValue(final int index) {
+        final Object o = get(index);
+        if (o == null) {
+            return new JsonValue();
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue;
+        }
+        if (o instanceof final String s) {
+            return new JsonValue(StringUtil.toCodePoints(s), JsonValueType.STRING);
+        }
+        if (o instanceof final Number n) {
+            return new JsonValue(StringUtil.toCodePoints(n.toString()), JsonValueType.NUMBER);
+        }
+        if (o instanceof final Boolean b) {
+            return new JsonValue(StringUtil.toCodePoints(b.toString()), JsonValueType.BOOLEAN);
+        }
+        throw new InvalidValueException("""
+                The underlying value is not suitable to create an object of JsonValue.
+                The underlying value should be one of the types of JsonValue, String, Number, Boolean or null.""");
+    }
+
+    /**
+     * @param index the index to get value.
+     * @return the JsonBaseNode value or null. It will throw exception if the value
+     * is not an instance of JsonBaseNode.
+     * @since 12.0.11
+     */
+    default JsonBaseNode getValueAsJsonBaseNode(final int index) {
+        final Object o = get(index);
+        if (o == null) {
+            return null;
+        }
+        return (JsonBaseNode) o;
+    }
+
+    /**
+     * @param index the index to get value.
      * @return the JsonListNode value or null. It will throw exception if the value
-     *         is not an instance of JsonListNode.
+     * is not an instance of JsonListNode.
      * @since 12.0.4
      */
     default JsonListNode getValueAsJsonListNode(final int index) {
@@ -151,7 +259,7 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
     /**
      * @param index the index to get value.
      * @return the JsonMapNode value or null. It will throw exception if the value
-     *         is not an instance of JsonMapNode.
+     * is not an instance of JsonMapNode.
      * @since 12.0.4
      */
     default JsonMapNode getValueAsJsonMapNode(final int index) {
@@ -305,4 +413,67 @@ public sealed interface JsonListNode extends JsonBaseNode, List<Object>permits J
 
         return new WffBMArray(BMValueType.STRING);
     }
+
+    /**
+     * <pre><code>
+     *         class CustomJsonMap extends JsonMap {
+     *         }
+     *         class CustomList extends JsonList {
+     *         }
+     *
+     *         JsonMap jsonMap = new  JsonMap();
+     *         jsonMap.put("number", new JsonValue("14", JsonValueType.NUMBER));
+     *         jsonMap.put("string", "string value");
+     *         jsonMap.put("bool", true);
+     *         jsonMap.put("fornull1", new JsonValue());
+     *         jsonMap.put("fornull2", null);
+     *
+     *         JsonList jsonList = new JsonList();
+     *         jsonList.add(jsonMap);
+     *
+     *         CustomList convertedObject = jsonList.convertTo(
+     *         CustomJsonMap::new, CustomJsonMap::put, CustomList::new, CustomList::add, true);
+     * </code></pre>
+     *
+     * @param jsonObjectSupplier the supplier to provide new JSON object.
+     * @param putOperation       the TriConsumer of the supplied JSON object, the key and value.
+     * @param jsonArraySupplier  the supplier to provide new JSON array.
+     * @param addOperation       the BiConsumer of the supplied JSON array and value.
+     * @param <T>                the JSON object class type.
+     * @param <U>                the JSON array class type. It is the return type of the method.
+     * @param parseJsonValue     true to parse the JsonValue to appropriate value types if the underlying value is a JsonValue object.
+     * @return the converted object.
+     * @since 12.0.11
+     */
+    default <T, U> U convertTo(final Supplier<T> jsonObjectSupplier, final TriConsumer<T, String, Object> putOperation,
+                               final Supplier<U> jsonArraySupplier, final BiConsumer<U, Object> addOperation, final boolean parseJsonValue) {
+        final U u = jsonArraySupplier.get();
+        for (final Object value : this) {
+            if (value instanceof final JsonMapNode jsonMapNode) {
+                addOperation.accept(u, jsonMapNode.convertTo(jsonObjectSupplier, putOperation, jsonArraySupplier, addOperation, parseJsonValue));
+            } else if (value instanceof final JsonListNode jsonListNode) {
+                addOperation.accept(u, jsonListNode.convertTo(jsonObjectSupplier, putOperation, jsonArraySupplier, addOperation, parseJsonValue));
+            } else if (parseJsonValue && value instanceof final JsonValue jsonValue) {
+                switch (jsonValue.valueType()) {
+                    case NULL -> addOperation.accept(u, null);
+                    case ENCODED_STRING -> addOperation.accept(u, jsonValue.asString(true));
+                    case STRING -> addOperation.accept(u, jsonValue.asString());
+                    case NUMBER -> {
+                        final int[] codePoints = jsonValue.originalCodePoints();
+                        if (codePoints != null) {
+                            addOperation.accept(u, JsonNumberValueType.AUTO_INTEGER_LONG_BIG_DECIMAL.parse(
+                                    codePoints, new int[]{0, codePoints.length - 1}));
+                        } else {
+                            addOperation.accept(u, value);
+                        }
+                    }
+                    case BOOLEAN -> addOperation.accept(u, jsonValue.asBoolean());
+                }
+            } else {
+                addOperation.accept(u, value);
+            }
+        }
+        return u;
+    }
+
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonMapNode.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonMapNode.java
@@ -15,22 +15,26 @@
  */
 package com.webfirmframework.wffweb.json;
 
+import com.webfirmframework.wffweb.InvalidValueException;
+import com.webfirmframework.wffweb.TriConsumer;
+import com.webfirmframework.wffweb.util.StringUtil;
+import com.webfirmframework.wffweb.wffbm.data.WffBMObject;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import com.webfirmframework.wffweb.InvalidValueException;
-import com.webfirmframework.wffweb.wffbm.data.WffBMObject;
 
 /**
  * @since 12.0.4
  */
 public sealed interface JsonMapNode
-        extends JsonBaseNode, Map<String, Object>permits JsonMap, JsonConcurrentMap, JsonLinkedMap {
+        extends JsonBaseNode, Map<String, Object> permits JsonConcurrentMap, JsonConcurrentSkipListMap, JsonLinkedMap, JsonMap {
 
     /**
      * @param key the key to get value.
@@ -48,13 +52,66 @@ public sealed interface JsonMapNode
         if (o instanceof final String s) {
             return s;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return JsonValueType.ENCODED_STRING.equals(jsonValue.valueType()) ? jsonValue.asString(true) : jsonValue.asString(false);
+        }
+        return o.toString();
+    }
+
+    /**
+     * @param key                        the key to get value.
+     * @param decodeUnicodeCharsSequence true to decode the Unicode chars sequences like <span>\</span><span>u2122</span> to Java chars or false to use as it is.
+     * @return the string value or null.
+     * @since 12.0.11
+     */
+    default String getValueAsString(final String key, final boolean decodeUnicodeCharsSequence) {
+        if (key == null) {
+            return null;
+        }
+        final Object o = get(key);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof final String s) {
+            if (decodeUnicodeCharsSequence) {
+                final int[] codePoints = StringUtil.toCodePoints(s);
+                return JsonStringUtil.toUnicodeCharsDecodedString(codePoints, 0, codePoints.length);
+            }
+            return s;
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return JsonValueType.ENCODED_STRING.equals(jsonValue.valueType()) ? jsonValue.asString(true, decodeUnicodeCharsSequence) : jsonValue.asString(false, decodeUnicodeCharsSequence);
+        }
         return o.toString();
     }
 
     /**
      * @param key the key to get value.
+     * @return the Boolean value or null. It will throw exception if the value is
+     * not parsable to Boolean.
+     * @since 12.0.11
+     */
+    default Boolean getValueAsBoolean(final String key) {
+        if (key == null) {
+            return null;
+        }
+        final Object o = get(key);
+        if (o == null) {
+            return null;
+        }
+        if (o instanceof final Boolean i) {
+            return i;
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asBoolean();
+        }
+        return Boolean.valueOf(o.toString());
+    }
+
+    /**
+     * @param key the key to get value.
      * @return the Integer value or null. It will throw exception if the value is
-     *         not parsable to integer.
+     * not parsable to integer.
      * @since 12.0.4
      */
     default Integer getValueAsInteger(final String key) {
@@ -68,13 +125,16 @@ public sealed interface JsonMapNode
         if (o instanceof final Integer i) {
             return i;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asInteger();
+        }
         return Integer.valueOf(o.toString());
     }
 
     /**
      * @param key the key to get value.
      * @return the Long value or null. It will throw exception if the value is not
-     *         parsable to Long.
+     * parsable to Long.
      * @since 12.0.4
      */
     default Long getValueAsLong(final String key) {
@@ -88,13 +148,16 @@ public sealed interface JsonMapNode
         if (o instanceof final Long l) {
             return l;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asLong();
+        }
         return Long.valueOf(o.toString());
     }
 
     /**
      * @param key the key to get value.
      * @return the Double value or null. It will throw exception if the value is not
-     *         parsable to Double.
+     * parsable to Double.
      * @since 12.0.4
      */
     default Double getValueAsDouble(final String key) {
@@ -108,13 +171,16 @@ public sealed interface JsonMapNode
         if (o instanceof final Double l) {
             return l;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asDouble();
+        }
         return Double.valueOf(o.toString());
     }
 
     /**
      * @param key the key to get value.
      * @return the BigInteger value or null. It will throw exception if the value is
-     *         not parsable to BigInteger.
+     * not parsable to BigInteger.
      * @since 12.0.4
      */
     default BigInteger getValueAsBigInteger(final String key) {
@@ -128,13 +194,16 @@ public sealed interface JsonMapNode
         if (o instanceof final BigInteger bi) {
             return bi;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asBigInteger();
+        }
         return new BigInteger(o.toString());
     }
 
     /**
      * @param key the key to get value.
      * @return the BigDecimal value or null. It will throw exception if the value is
-     *         not parsable to BigDecimal.
+     * not parsable to BigDecimal.
      * @since 12.0.4
      */
     default BigDecimal getValueAsBigDecimal(final String key) {
@@ -148,13 +217,64 @@ public sealed interface JsonMapNode
         if (o instanceof final BigDecimal bd) {
             return bd;
         }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue.asBigDecimal();
+        }
         return new BigDecimal(o.toString());
     }
 
     /**
      * @param key the key to get value.
+     * @return the value as JsonValue object.
+     * @throws InvalidValueException if the value is not suitable to create an object of JsonValue.
+     * @since 12.0.11
+     */
+    default JsonValue getValueAsJsonValue(final String key) {
+        if (key == null) {
+            return null;
+        }
+        final Object o = get(key);
+        if (o == null) {
+            return new JsonValue();
+        }
+        if (o instanceof final JsonValue jsonValue) {
+            return jsonValue;
+        }
+        if (o instanceof final String s) {
+            return new JsonValue(StringUtil.toCodePoints(s), JsonValueType.STRING);
+        }
+        if (o instanceof final Number n) {
+            return new JsonValue(StringUtil.toCodePoints(n.toString()), JsonValueType.NUMBER);
+        }
+        if (o instanceof final Boolean b) {
+            return new JsonValue(StringUtil.toCodePoints(b.toString()), JsonValueType.BOOLEAN);
+        }
+        throw new InvalidValueException("""
+                The underlying value is not suitable to create an object of JsonValue.
+                The underlying value should be one of the types of JsonValue, String, Number, Boolean or null.""");
+    }
+
+    /**
+     * @param key the key to get value.
+     * @return the JsonBaseNode value or null. It will throw exception if the value
+     * is not an instance of JsonBaseNode.
+     * @since 12.0.11
+     */
+    default JsonBaseNode getValueAsJsonBaseNode(final String key) {
+        if (key == null) {
+            return null;
+        }
+        final Object o = get(key);
+        if (o == null) {
+            return null;
+        }
+        return (JsonBaseNode) o;
+    }
+
+    /**
+     * @param key the key to get value.
      * @return the JsonListNode value or null. It will throw exception if the value
-     *         is not an instance of JsonListNode.
+     * is not an instance of JsonListNode.
      * @since 12.0.4
      */
     default JsonListNode getValueAsJsonListNode(final String key) {
@@ -171,7 +291,7 @@ public sealed interface JsonMapNode
     /**
      * @param key the key to get value.
      * @return the JsonMapNode value or null. It will throw exception if the value
-     *         is not an instance of JsonMapNode.
+     * is not an instance of JsonMapNode.
      * @since 12.0.4
      */
     default JsonMapNode getValueAsJsonMapNode(final String key) {
@@ -265,4 +385,70 @@ public sealed interface JsonMapNode
 
         return bmObject;
     }
+
+
+    /**
+     * <pre><code>
+     *         class CustomJsonMap extends JsonMap {
+     *         }
+     *         class CustomList extends JsonList {
+     *         }
+     *
+     *         JsonMap jsonMap = new  JsonMap();
+     *         jsonMap.put("number", new JsonValue("14", JsonValueType.NUMBER));
+     *         jsonMap.put("string", "string value");
+     *         jsonMap.put("bool", true);
+     *         jsonMap.put("fornull1", new JsonValue());
+     *         jsonMap.put("fornull2", null);
+     *
+     *         JsonList jsonList = new JsonList();
+     *         jsonList.add("one");
+     *         jsonList.add("two");
+     *         jsonMap.put("jsonList", jsonList);
+     *
+     *         CustomJsonMap convertedObject = jsonMap.convertTo(
+     *         CustomJsonMap::new, CustomJsonMap::put, CustomList::new, CustomList::add, true);
+     * </code></pre>
+     *
+     * @param jsonObjectSupplier the supplier to provide new JSON object.
+     * @param putOperation       the TriConsumer of the supplied JSON object, the key and value.
+     * @param jsonArraySupplier  the supplier to provide new JSON array.
+     * @param addOperation       the BiConsumer of the supplied JSON array and value.
+     * @param <T>                the JSON object class type. It is the return type of the method.
+     * @param <U>                the JSON array class type.
+     * @param parseJsonValue     true to parse the JsonValue to appropriate value types if the underlying value is a JsonValue object.
+     * @return the converted object.
+     * @since 12.0.11
+     */
+    default <T, U> T convertTo(final Supplier<T> jsonObjectSupplier, final TriConsumer<T, String, Object> putOperation,
+                               final Supplier<U> jsonArraySupplier, final BiConsumer<U, Object> addOperation, final boolean parseJsonValue) {
+        final T t = jsonObjectSupplier.get();
+        for (final Entry<String, Object> entry : entrySet()) {
+            if (entry.getValue() instanceof final JsonMapNode jsonMapNode) {
+                putOperation.accept(t, entry.getKey(), jsonMapNode.convertTo(jsonObjectSupplier, putOperation, jsonArraySupplier, addOperation, parseJsonValue));
+            } else if (entry.getValue() instanceof final JsonListNode jsonListNode) {
+                putOperation.accept(t, entry.getKey(), jsonListNode.convertTo(jsonObjectSupplier, putOperation, jsonArraySupplier, addOperation, parseJsonValue));
+            } else if (parseJsonValue && entry.getValue() instanceof final JsonValue jsonValue) {
+                switch (jsonValue.valueType()) {
+                    case NULL -> putOperation.accept(t, entry.getKey(), null);
+                    case ENCODED_STRING -> putOperation.accept(t, entry.getKey(), jsonValue.asString(true));
+                    case STRING -> putOperation.accept(t, entry.getKey(), jsonValue.asString());
+                    case NUMBER -> {
+                        final int[] codePoints = jsonValue.originalCodePoints();
+                        if (codePoints != null) {
+                            putOperation.accept(t, entry.getKey(), JsonNumberValueType.AUTO_INTEGER_LONG_BIG_DECIMAL.parse(
+                                    codePoints, new int[]{0, codePoints.length - 1}));
+                        } else {
+                            putOperation.accept(t, entry.getKey(), entry.getValue());
+                        }
+                    }
+                    case BOOLEAN -> putOperation.accept(t, entry.getKey(), jsonValue.asBoolean());
+                }
+            } else {
+                putOperation.accept(t, entry.getKey(), entry.getValue());
+            }
+        }
+        return t;
+    }
+
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonNumberValueType.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonNumberValueType.java
@@ -51,14 +51,14 @@ public enum JsonNumberValueType {
     },
 
     /**
-     * To represent JsonValue wrapper object as null value.
+     * To represent JsonValue wrapper object as value.
      *
      * @since 12.0.4
      */
     JSON_VALUE {
         @Override
         JsonValue parse(final int[] codePoints, final int[] startEndIndices) {
-            return new JsonValue(codePoints, JsonValueType.NUMBER);
+            return new JsonValue(JsonCodePointUtil.cut(codePoints, startEndIndices), JsonValueType.NUMBER);
         }
     },
 

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonObjectType.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonObjectType.java
@@ -19,12 +19,14 @@ package com.webfirmframework.wffweb.json;
  * @since 12.0.4
  */
 public enum JsonObjectType {
+
     /**
      * represents JsonMap which is extended by HashMap.
      *
      * @since 12.0.4
      */
     JSON_MAP,
+
     /**
      * represents JsonConcurrentMap which is extended by ConcurrentHashMap.
      *
@@ -51,5 +53,12 @@ public enum JsonObjectType {
      *
      * @since 12.0.6
      */
-    CUSTOM_JSON_MAP;
+    CUSTOM_JSON_MAP,
+
+    /**
+     * represents JsonConcurrentSkipListMap which is extended by ConcurrentSkipListMap.
+     *
+     * @since 12.0.10
+     */
+    JSON_CONCURRENT_SKIP_LIST_MAP;
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonParser.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonParser.java
@@ -15,17 +15,12 @@
  */
 package com.webfirmframework.wffweb.json;
 
-import java.math.BigDecimal;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
-
 import com.webfirmframework.wffweb.InvalidUsageException;
+import com.webfirmframework.wffweb.util.StringUtil;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * Refer {@link #newBuilder()} for creating object with custom config.
@@ -33,34 +28,40 @@ import com.webfirmframework.wffweb.InvalidUsageException;
  * @since 12.0.6
  */
 public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayType,
-        boolean jsonNumberArrayUniformValueType, JsonNumberValueType jsonNumberValueTypeForObject,
-        JsonNumberValueType jsonNumberValueTypeForArray, JsonStringValueType jsonStringValueTypeForObject,
-        JsonStringValueType jsonStringValueTypeForArray, JsonBooleanValueType jsonBooleanValueTypeForObject,
-        JsonBooleanValueType jsonBooleanValueTypeForArray, JsonNullValueType jsonNullValueTypeForObject,
-        JsonNullValueType jsonNullValueTypeForArray, boolean validateEscapeSequence,
-        Supplier<Map<String, Object>> jsonMapFactory, Supplier<List<Object>> jsonListFactory) {
+                         boolean jsonNumberArrayUniformValueType, JsonNumberValueType jsonNumberValueTypeForObject,
+                         JsonNumberValueType jsonNumberValueTypeForArray,
+                         JsonStringValueType jsonStringValueTypeForObject,
+                         JsonStringValueType jsonStringValueTypeForArray,
+                         JsonBooleanValueType jsonBooleanValueTypeForObject,
+                         JsonBooleanValueType jsonBooleanValueTypeForArray,
+                         JsonNullValueType jsonNullValueTypeForObject,
+                         JsonNullValueType jsonNullValueTypeForArray, boolean validateEscapeSequence,
+                         Supplier<Map<String, Object>> jsonMapFactory, Supplier<List<Object>> jsonListFactory) {
 
     // private static final int CURLY_BRACE_START_CODE_POINT = "{".codePointAt(0);
     private static final int CURLY_BRACE_START_CODE_POINT = 123;
 
-//    private static final int CURLY_BRACE_END_CODE_POINT = "}".codePointAt(0);
+    //    private static final int CURLY_BRACE_END_CODE_POINT = "}".codePointAt(0);
     private static final int CURLY_BRACE_END_CODE_POINT = 125;
 
-//    private static final int SQUARE_BRACKET_START_CODE_POINT = "[".codePointAt(0);
+    //    private static final int SQUARE_BRACKET_START_CODE_POINT = "[".codePointAt(0);
     private static final int SQUARE_BRACKET_START_CODE_POINT = 91;
 
-//    private static final int SQUARE_BRACKET_END_CODE_POINT = "]".codePointAt(0);
+    //    private static final int SQUARE_BRACKET_END_CODE_POINT = "]".codePointAt(0);
     private static final int SQUARE_BRACKET_END_CODE_POINT = 93;
 
-    private static final int COMMA_CODE_POINT = ",".codePointAt(0);
+//    private static final int COMMA_CODE_POINT = ",".codePointAt(0);
+    private static final int COMMA_CODE_POINT = 44;
 
-    private static final int COLON_CODE_POINT = ":".codePointAt(0);
+//    private static final int COLON_CODE_POINT = ":".codePointAt(0);
+    private static final int COLON_CODE_POINT = 58;
 
     private static final int ESCAPE_CODE_POINT = JsonCodePointUtil.ESCAPE_CODE_POINT;
 
     private static final int DOUBLE_QUOTES_CODE_POINT = JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT;
 
-    private static final int[] NULL_CODE_POINTS = "null".codePoints().toArray();
+//    private static final int[] NULL_CODE_POINTS = "null".codePoints().toArray();
+    private static final int[] NULL_CODE_POINTS = { 110, 117, 108, 108 };
 
     // Note: it should be sorted in ascending order, call
     // Arrays.sort(JSON_NODE_DELIMS_SORTED_ASC); to dynamically sort
@@ -177,14 +178,14 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
     }
 
     public JsonParser(final JsonObjectType jsonObjectType, final JsonArrayType jsonArrayType,
-            final boolean jsonNumberArrayUniformValueType, final JsonNumberValueType jsonNumberValueTypeForObject,
-            final JsonNumberValueType jsonNumberValueTypeForArray,
-            final JsonStringValueType jsonStringValueTypeForObject,
-            final JsonStringValueType jsonStringValueTypeForArray,
-            final JsonBooleanValueType jsonBooleanValueTypeForObject,
-            final JsonBooleanValueType jsonBooleanValueTypeForArray, final JsonNullValueType jsonNullValueTypeForObject,
-            final JsonNullValueType jsonNullValueTypeForArray, final boolean validateEscapeSequence,
-            final Supplier<Map<String, Object>> jsonMapFactory, final Supplier<List<Object>> jsonListFactory) {
+                      final boolean jsonNumberArrayUniformValueType, final JsonNumberValueType jsonNumberValueTypeForObject,
+                      final JsonNumberValueType jsonNumberValueTypeForArray,
+                      final JsonStringValueType jsonStringValueTypeForObject,
+                      final JsonStringValueType jsonStringValueTypeForArray,
+                      final JsonBooleanValueType jsonBooleanValueTypeForObject,
+                      final JsonBooleanValueType jsonBooleanValueTypeForArray, final JsonNullValueType jsonNullValueTypeForObject,
+                      final JsonNullValueType jsonNullValueTypeForArray, final boolean validateEscapeSequence,
+                      final Supplier<Map<String, Object>> jsonMapFactory, final Supplier<List<Object>> jsonListFactory) {
         this.jsonObjectType = jsonObjectType != null ? jsonObjectType : JsonObjectType.UNMODIFIABLE_MAP;
         this.jsonArrayType = jsonArrayType != null ? jsonArrayType : JsonArrayType.UNMODIFIABLE_LIST;
         this.jsonNumberArrayUniformValueType = jsonNumberArrayUniformValueType;
@@ -215,13 +216,13 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
      * @since 12.0.4
      */
     public JsonParser(final JsonObjectType jsonObjectType, final JsonArrayType jsonArrayType,
-            final boolean jsonNumberArrayUniformValueType, final JsonNumberValueType jsonNumberValueTypeForObject,
-            final JsonNumberValueType jsonNumberValueTypeForArray,
-            final JsonStringValueType jsonStringValueTypeForObject,
-            final JsonStringValueType jsonStringValueTypeForArray,
-            final JsonBooleanValueType jsonBooleanValueTypeForObject,
-            final JsonBooleanValueType jsonBooleanValueTypeForArray, final JsonNullValueType jsonNullValueTypeForObject,
-            final JsonNullValueType jsonNullValueTypeForArray, final boolean validateEscapeSequence) {
+                      final boolean jsonNumberArrayUniformValueType, final JsonNumberValueType jsonNumberValueTypeForObject,
+                      final JsonNumberValueType jsonNumberValueTypeForArray,
+                      final JsonStringValueType jsonStringValueTypeForObject,
+                      final JsonStringValueType jsonStringValueTypeForArray,
+                      final JsonBooleanValueType jsonBooleanValueTypeForObject,
+                      final JsonBooleanValueType jsonBooleanValueTypeForArray, final JsonNullValueType jsonNullValueTypeForObject,
+                      final JsonNullValueType jsonNullValueTypeForArray, final boolean validateEscapeSequence) {
         this(jsonObjectType, jsonArrayType, jsonNumberArrayUniformValueType, jsonNumberValueTypeForObject,
                 jsonNumberValueTypeForArray, jsonStringValueTypeForObject, jsonStringValueTypeForArray,
                 jsonBooleanValueTypeForObject, jsonBooleanValueTypeForArray, jsonNullValueTypeForObject,
@@ -386,41 +387,42 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
 
     private Map<String, Object> newMap(final int length) {
         return switch (jsonObjectType) {
-        case JSON_MAP, UNMODIFIABLE_MAP -> new JsonMap(length);
-        case JSON_CONCURRENT_MAP -> new JsonConcurrentMap(length);
-        case JSON_LINKED_MAP -> new JsonLinkedMap(length);
-        case CUSTOM_JSON_MAP -> {
-            if (jsonMapFactory != null) {
-                final Map<String, Object> map = jsonMapFactory.get();
-                if (map != null) {
-                    yield map;
+            case JSON_MAP, UNMODIFIABLE_MAP -> new JsonMap(length);
+            case JSON_CONCURRENT_MAP -> new JsonConcurrentMap(length);
+            case JSON_CONCURRENT_SKIP_LIST_MAP -> new JsonConcurrentSkipListMap();
+            case JSON_LINKED_MAP -> new JsonLinkedMap(length);
+            case CUSTOM_JSON_MAP -> {
+                if (jsonMapFactory != null) {
+                    final Map<String, Object> map = jsonMapFactory.get();
+                    if (map != null) {
+                        yield map;
+                    }
                 }
+                throw new InvalidUsageException(
+                        "If JsonObjectType.JSON_CUSTOM_MAP is used jsonMapFactory should be provided and the supplier should always return an object.");
             }
-            throw new InvalidUsageException(
-                    "If JsonObjectType.JSON_CUSTOM_MAP is used jsonMapFactory should be provided and the supplier should always return an object.");
-        }
         };
     }
 
     private List<Object> newList(final int initialCapacity) {
         return switch (jsonArrayType) {
-        case JSON_LIST, UNMODIFIABLE_LIST -> new JsonList(initialCapacity);
-        case JSON_LINKED_LIST -> new JsonLinkedList();
-        case CUSTOM_JSON_LIST -> {
-            if (jsonListFactory != null) {
-                final List<Object> list = jsonListFactory.get();
-                if (list != null) {
-                    yield list;
+            case JSON_LIST, UNMODIFIABLE_LIST -> new JsonList(initialCapacity);
+            case JSON_LINKED_LIST -> new JsonLinkedList();
+            case CUSTOM_JSON_LIST -> {
+                if (jsonListFactory != null) {
+                    final List<Object> list = jsonListFactory.get();
+                    if (list != null) {
+                        yield list;
+                    }
                 }
+                throw new InvalidUsageException(
+                        "If JsonArrayType.JSON_CUSTOM_LIST is used jsonListFactory should be provided and the supplier should always return an object.");
             }
-            throw new InvalidUsageException(
-                    "If JsonArrayType.JSON_CUSTOM_LIST is used jsonListFactory should be provided and the supplier should always return an object.");
-        }
         };
     }
 
     private Map<String, Object> parseJsonObject(final int[] jsonCodePoints, final int startIndex, final int endIndex,
-            final List<JsonSection> idToJsonSection) {
+                                                final List<JsonSection> idToJsonSection) {
         if (isJsonObject(jsonCodePoints, startIndex, endIndex)) {
 
             final int length = endIndex - startIndex + 1;
@@ -477,7 +479,8 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
                     final JsonSection jsonSection = idToJsonSection.get(indexOfId);
                     idToJsonSection.set(indexOfId, null);
                     if (JsonSectionType.STRING.equals(jsonSection.jsonSectionType())) {
-                        key = jsonSection.getJsonStringPart();
+                        final int[] keyCodePoints = jsonSection.getJsonStringPartCodePoints();
+                        key = JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(keyCodePoints, 0, keyCodePoints.length);
                     } else {
                         throw new IllegalJsonFormatException(
                                 "Invalid JSON! It contains illegal JSON object key format!");
@@ -491,7 +494,12 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
                     final int indexOfId = Math.negateExact(id) - 1;
                     final JsonSection jsonSection = idToJsonSection.get(indexOfId);
                     idToJsonSection.set(indexOfId, null);
-                    previous = keyToValue.put(key, jsonSection.getJsonObjectArrayOrStringPart());
+                    if (JsonSectionType.STRING.equals(jsonSection.jsonSectionType())) {
+                        final int[] jsonStringPartCodePoints = jsonSection.getJsonStringPartCodePoints();
+                        previous = keyToValue.put(key, jsonStringValueTypeForObject.parse(jsonStringPartCodePoints));
+                    } else {
+                        previous = keyToValue.put(key, jsonSection.getJsonObjectOrArray());
+                    }
                 } else if (isNullValue(valuePartCodePoints, valuePartCodePointsIndices)) {
                     previous = keyToValue.put(key, jsonNullValueTypeForObject.nullValue());
                 } else if (isBooleanValue(valuePartCodePoints, valuePartCodePointsIndices)) {
@@ -514,7 +522,7 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
     }
 
     private List<Object> parseJsonArray(final int[] jsonCodePoints, final int startIndex, final int endIndex,
-            final List<JsonSection> idToJsonSection) {
+                                        final List<JsonSection> idToJsonSection) {
         if (isJsonArray(jsonCodePoints, startIndex, endIndex)) {
             final int length = endIndex - startIndex + 1;
             if (length == 2) {
@@ -546,8 +554,12 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
                     final int indexOfId = Math.negateExact(id) - 1;
                     final JsonSection jsonSection = idToJsonSection.get(indexOfId);
                     idToJsonSection.set(indexOfId, null);
-                    final Object v = jsonSection.getJsonObjectArrayOrStringPart();
-                    values.add(v);
+                    if (JsonSectionType.STRING.equals(jsonSection.jsonSectionType())) {
+                        final int[] jsonStringPartCodePoints = jsonSection.getJsonStringPartCodePoints();
+                        values.add(jsonStringValueTypeForArray.parse(jsonStringPartCodePoints));
+                    } else {
+                        values.add(jsonSection.getJsonObjectOrArray());
+                    }
                     nullOrNumberValuesOnly = false;
                 } else if (isNullValue(fullPartValueCodePoints, fullPartValueCodePointsIndices)) {
                     values.add(jsonNullValueTypeForArray.nullValue());
@@ -562,7 +574,7 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
             }
             if (jsonNumberArrayUniformValueType && nullOrNumberValuesOnly
                     && (JsonNumberValueType.AUTO_INTEGER_LONG_BIG_DECIMAL.equals(jsonNumberValueTypeForArray)
-                            || JsonNumberValueType.AUTO_INTEGER_LONG_DOUBLE.equals(jsonNumberValueTypeForArray))) {
+                    || JsonNumberValueType.AUTO_INTEGER_LONG_DOUBLE.equals(jsonNumberValueTypeForArray))) {
 
                 boolean containsMixedNumberTypes = false;
                 boolean convertToLong = false;
@@ -640,7 +652,7 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
         if (length <= 0) {
             return "";
         }
-        return new String(codePoints, startIndexAfterDoubleQuote, length);
+        return JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(codePoints, startIndexAfterDoubleQuote, length);
     }
 
     private JsonSection buildOuterMostJsonSection(final int[] jsonCodePoints, final int[] startEndIndices) {
@@ -690,79 +702,85 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
                 continue;
             }
             switch (codePoint) {
-            case CURLY_BRACE_START_CODE_POINT -> {
-                nodeId--;
-                final JsonSection jsonSection = new JsonSection(nodeId, JsonSectionType.OBJECT, i);
-                objectNodeDeque.offerFirst(jsonSection);
-                idToJsonSection.add(jsonSection);
-
-                if (outerMostJsonSection == null) {
-                    outerMostJsonSection = jsonSection;
-                }
-            }
-            case CURLY_BRACE_END_CODE_POINT -> {
-                final JsonSection jsonSection = objectNodeDeque.poll();
-                if (jsonSection == null || (jsonSection.startIndex() == 0 && i != endIndex)) {
-                    throw new IllegalJsonFormatException("Invalid JSON! It contains invalid JSON object.");
-                }
-                jsonSection.setEndIndex(i);
-                jsonSection.setJsonObject(parseJsonObject(jsonCodePoints, jsonSection.startIndex(),
-                        jsonSection.getEndIndex(), idToJsonSection));
-                for (int j = idToJsonSection.size() - 1; j > 0; j--) {
-                    if (idToJsonSection.get(j) == null) {
-                        idToJsonSection.remove(j);
-                        nodeId = -j;
-                    } else {
-                        break;
-                    }
-                }
-                fillJsonSectionId(jsonCodePoints, jsonSection);
-            }
-            case SQUARE_BRACKET_START_CODE_POINT -> {
-                nodeId--;
-                final JsonSection jsonSection = new JsonSection(nodeId, JsonSectionType.ARRAY, i);
-                arrayNodeDeque.offerFirst(jsonSection);
-                idToJsonSection.add(jsonSection);
-                if (outerMostJsonSection == null) {
-                    outerMostJsonSection = jsonSection;
-                }
-            }
-            case SQUARE_BRACKET_END_CODE_POINT -> {
-                final JsonSection jsonSection = arrayNodeDeque.poll();
-                if (jsonSection == null || (jsonSection.startIndex() == 0 && i != endIndex)) {
-                    throw new IllegalJsonFormatException("Invalid JSON! It contains invalid JSON array.");
-                }
-                jsonSection.setEndIndex(i);
-                jsonSection.setJsonArray(parseJsonArray(jsonCodePoints, jsonSection.startIndex(),
-                        jsonSection.getEndIndex(), idToJsonSection));
-                for (int j = idToJsonSection.size() - 1; j > 0; j--) {
-                    if (idToJsonSection.get(j) == null) {
-                        idToJsonSection.remove(j);
-                        nodeId = -j;
-                    } else {
-                        break;
-                    }
-                }
-                fillJsonSectionId(jsonCodePoints, jsonSection);
-            }
-            case DOUBLE_QUOTES_CODE_POINT -> {
-                if (jsonStringNodeIsNull) {
+                case CURLY_BRACE_START_CODE_POINT -> {
                     nodeId--;
-                    final JsonSection jsonSection = new JsonSection(nodeId, JsonSectionType.STRING, i);
-                    jsonStringNode = jsonSection;
+                    final JsonSection jsonSection = new JsonSection(nodeId, JsonSectionType.OBJECT, i);
+                    objectNodeDeque.offerFirst(jsonSection);
+                    idToJsonSection.add(jsonSection);
+
+                    if (outerMostJsonSection == null) {
+                        outerMostJsonSection = jsonSection;
+                    }
+                }
+                case CURLY_BRACE_END_CODE_POINT -> {
+                    final JsonSection jsonSection = objectNodeDeque.poll();
+                    if (jsonSection == null || (jsonSection.startIndex() == 0 && i != endIndex)) {
+                        throw new IllegalJsonFormatException("Invalid JSON! It contains invalid JSON object.");
+                    }
+                    jsonSection.setEndIndex(i);
+                    jsonSection.setJsonObject(parseJsonObject(jsonCodePoints, jsonSection.startIndex(),
+                            jsonSection.getEndIndex(), idToJsonSection));
+                    for (int j = idToJsonSection.size() - 1; j > 0; j--) {
+                        if (idToJsonSection.get(j) == null) {
+                            idToJsonSection.remove(j);
+                            nodeId = -j;
+                        } else {
+                            break;
+                        }
+                    }
+                    fillJsonSectionId(jsonCodePoints, jsonSection);
+                }
+                case SQUARE_BRACKET_START_CODE_POINT -> {
+                    nodeId--;
+                    final JsonSection jsonSection = new JsonSection(nodeId, JsonSectionType.ARRAY, i);
+                    arrayNodeDeque.offerFirst(jsonSection);
                     idToJsonSection.add(jsonSection);
                     if (outerMostJsonSection == null) {
                         outerMostJsonSection = jsonSection;
                     }
-                } else {
-                    final JsonSection jsonSection = jsonStringNode;
+                }
+                case SQUARE_BRACKET_END_CODE_POINT -> {
+                    final JsonSection jsonSection = arrayNodeDeque.poll();
+                    if (jsonSection == null || (jsonSection.startIndex() == 0 && i != endIndex)) {
+                        throw new IllegalJsonFormatException("Invalid JSON! It contains invalid JSON array.");
+                    }
                     jsonSection.setEndIndex(i);
-                    jsonStringNode = null;
-                    jsonSection.setJsonStringPart(
-                            parseJsonString(jsonCodePoints, jsonSection.startIndex(), jsonSection.getEndIndex()));
+                    jsonSection.setJsonArray(parseJsonArray(jsonCodePoints, jsonSection.startIndex(),
+                            jsonSection.getEndIndex(), idToJsonSection));
+                    for (int j = idToJsonSection.size() - 1; j > 0; j--) {
+                        if (idToJsonSection.get(j) == null) {
+                            idToJsonSection.remove(j);
+                            nodeId = -j;
+                        } else {
+                            break;
+                        }
+                    }
                     fillJsonSectionId(jsonCodePoints, jsonSection);
                 }
-            }
+                case DOUBLE_QUOTES_CODE_POINT -> {
+                    if (jsonStringNodeIsNull) {
+                        nodeId--;
+                        final JsonSection jsonSection = new JsonSection(nodeId, JsonSectionType.STRING, i);
+                        jsonStringNode = jsonSection;
+                        idToJsonSection.add(jsonSection);
+                        if (outerMostJsonSection == null) {
+                            outerMostJsonSection = jsonSection;
+                        }
+                    } else {
+                        final JsonSection jsonSection = jsonStringNode;
+                        jsonSection.setEndIndex(i);
+                        jsonStringNode = null;
+                        final int startIndexAfterDoubleQuote = jsonSection.startIndex() + 1;
+                        final int endIndexBeforeDoubleQuote = jsonSection.getEndIndex() - 1;
+                        final int length = endIndexBeforeDoubleQuote - startIndexAfterDoubleQuote + 1;
+                        final int[] stringPartCodePoints = length > 0 ? new int[length] : new int[0];
+                        if (length > 0) {
+                            System.arraycopy(jsonCodePoints, startIndexAfterDoubleQuote, stringPartCodePoints, 0, length);
+                        }
+                        jsonSection.setJsonStringPartCodePoints(stringPartCodePoints);
+                        fillJsonSectionId(jsonCodePoints, jsonSection);
+                    }
+                }
             }
         }
 
@@ -798,7 +816,7 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
      * @since 12.0.4
      */
     public Object parseJson(final String json) {
-        final int[] jsonCodePoints = json.codePoints().toArray();
+        final int[] jsonCodePoints = StringUtil.toCodePoints(json);
         final int[] startEndIndices = JsonCodePointUtil.findFirstAndLastNonWhitespaceIndices(jsonCodePoints);
         final boolean isBooleanValue = isBooleanValue(jsonCodePoints, startEndIndices);
         final boolean notJsonArrayObjectStringValue = !isJsonString(jsonCodePoints, startEndIndices)
@@ -831,7 +849,8 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
             return outerMostJsonSection.getJsonArray();
         }
         if (JsonSectionType.STRING.equals(outerMostJsonSection.jsonSectionType())) {
-            return outerMostJsonSection.getJsonStringPart();
+            final int[] jsonStringPartCodePoints = outerMostJsonSection.getJsonStringPartCodePoints();
+            return JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(jsonStringPartCodePoints, 0, jsonStringPartCodePoints.length);
         }
         return null;
     }
@@ -842,7 +861,7 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
      * @since 12.0.4
      */
     public Map<String, Object> parseJsonObject(final String json) {
-        final int[] jsonCodePoints = json.codePoints().toArray();
+        final int[] jsonCodePoints = StringUtil.toCodePoints(json);
         final int[] startEndIndices = JsonCodePointUtil.findFirstAndLastNonWhitespaceIndices(jsonCodePoints);
         if (isJsonObject(jsonCodePoints, startEndIndices)) {
             final JsonSection outerMostJsonSection = buildOuterMostJsonSection(jsonCodePoints, startEndIndices);
@@ -857,7 +876,7 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
      * @since 12.0.4
      */
     public List<Object> parseJsonArray(final String json) {
-        final int[] jsonCodePoints = json.codePoints().toArray();
+        final int[] jsonCodePoints = StringUtil.toCodePoints(json);
         final int[] startEndIndices = JsonCodePointUtil.findFirstAndLastNonWhitespaceIndices(jsonCodePoints);
         if (isJsonArray(jsonCodePoints, startEndIndices)) {
             final JsonSection outerMostJsonSection = buildOuterMostJsonSection(jsonCodePoints, startEndIndices);
@@ -872,11 +891,12 @@ public record JsonParser(JsonObjectType jsonObjectType, JsonArrayType jsonArrayT
      * @since 12.0.4
      */
     public String parseJsonEncodedStringValue(final String json) {
-        final int[] jsonCodePoints = json.codePoints().toArray();
+        final int[] jsonCodePoints = StringUtil.toCodePoints(json);
         final int[] startEndIndices = JsonCodePointUtil.findFirstAndLastNonWhitespaceIndices(jsonCodePoints);
         if (isJsonString(jsonCodePoints, startEndIndices)) {
             final JsonSection outerMostJsonSection = buildOuterMostJsonSection(jsonCodePoints, startEndIndices);
-            return outerMostJsonSection.getJsonStringPart();
+            final int[] jsonStringPartCodePoints = outerMostJsonSection.getJsonStringPartCodePoints();
+            return JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(jsonStringPartCodePoints, 0, jsonStringPartCodePoints.length);
         }
         throw new IllegalJsonFormatException("Invalid JSON encoded string value! It should start and end with \"");
     }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonSection.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonSection.java
@@ -35,9 +35,14 @@ final class JsonSection {
 
     private List<Object> jsonArray;
 
+    //not used anywhere
     private String jsonStringPart;
 
+    private int[] jsonStringPartCodePoints;
+
     private Object jsonObjectArrayOrStringPart;
+
+    private Object jsonObjectOrArray;
 
     private int endIndex = -1;
 
@@ -74,6 +79,7 @@ final class JsonSection {
     void setJsonObject(final Map<String, Object> jsonObject) {
         this.jsonObject = jsonObject;
         jsonObjectArrayOrStringPart = jsonObject;
+        jsonObjectOrArray = jsonObject;
     }
 
     List<Object> getJsonArray() {
@@ -83,19 +89,34 @@ final class JsonSection {
     void setJsonArray(final List<Object> jsonArray) {
         this.jsonArray = jsonArray;
         jsonObjectArrayOrStringPart = jsonArray;
+        jsonObjectOrArray = jsonArray;
     }
 
+    @Deprecated(since = "12.0.11", forRemoval = true)
     String getJsonStringPart() {
         return jsonStringPart;
     }
 
+    @Deprecated(since = "12.0.11", forRemoval = true)
     void setJsonStringPart(final String jsonStringPart) {
         this.jsonStringPart = jsonStringPart;
         jsonObjectArrayOrStringPart = jsonStringPart;
     }
 
+    @Deprecated(since = "12.0.11", forRemoval = true)
     Object getJsonObjectArrayOrStringPart() {
         return jsonObjectArrayOrStringPart;
     }
 
+    void setJsonStringPartCodePoints(final int[] jsonStringPartCodePoints) {
+        this.jsonStringPartCodePoints = jsonStringPartCodePoints;
+    }
+
+    int[] getJsonStringPartCodePoints() {
+        return jsonStringPartCodePoints;
+    }
+
+    Object getJsonObjectOrArray() {
+        return jsonObjectOrArray;
+    }
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonStringUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonStringUtil.java
@@ -15,6 +15,8 @@
  */
 package com.webfirmframework.wffweb.json;
 
+import com.webfirmframework.wffweb.util.StringUtil;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
@@ -27,55 +29,79 @@ import java.util.Map;
  */
 final class JsonStringUtil {
 
+    // private static final int SLASH_T_CODE_POINT = "\t".codePointAt(0);
+    private static final int SLASH_T_CODE_POINT = 9;
+
+    //    private static final int SLASH_B_CODE_POINT = "\b".codePointAt(0);//8
+    private static final int SLASH_B_CODE_POINT = 8;//8
+
+    //    private static final int SLASH_F_CODE_POINT = "\f".codePointAt(0);//12
+    private static final int SLASH_F_CODE_POINT = 12;//12
+
+    //    private static final int SLASH_SLASH_CODE_POINT = "\\".codePointAt(0);//92
+    private static final int SLASH_SLASH_CODE_POINT = 92;
+
+    //    private static final int FORWARD_SLASH_CODE_POINT = "/".codePointAt(0);
+    private static final int FORWARD_SLASH_CODE_POINT = 47;
+
+    //    private static final int[] SLASH_R_SLASH_N_CHARS = "\\r\\n".codePoints().toArray();
+    private static final int[] SLASH_R_SLASH_N_CHARS = {92, 114, 92, 110};
+
     // Note: it should be sorted in ascending order, call
     // Arrays.sort(JSON_ESCAPABLE_DELIMS_SORTED_ASC); to dynamically sort
     // this is only for json string
 //    [34, 47, 92, 98, 102, 110, 114, 116, 117]
 //    private static final int[] JSON_STRING_ESCAPABLE_DELIMS_SORTED_ASC = {
-//            JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT,
-//            "/".codePointAt(0),
-//            JsonCodePointUtil.ESCAPE_CODE_POINT,
-//            "b".codePointAt(0),
-//            "f".codePointAt(0),
-//            "n".codePointAt(0),
-//            "r".codePointAt(0),
-//            "t".codePointAt(0),
-//            JsonCodePointUtil.U_CODE_POINT,
+//            JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT, // 34
+//            "/".codePointAt(0), //47
+//            JsonCodePointUtil.ESCAPE_CODE_POINT,  //92
+//            "b".codePointAt(0),  //98
+//            "f".codePointAt(0),  //102
+//            "n".codePointAt(0),  //110
+//            "r".codePointAt(0),  //114
+//            "t".codePointAt(0),  //116
+//            JsonCodePointUtil.U_CODE_POINT,  //117
 //    };
 
     static boolean isJsonStringEscapableDelim(final int codePoint) {
         // for better performance, case is the integers in
         // JSON_STRING_ESCAPABLE_DELIMS_SORTED_ASC
         return switch (codePoint) {
-        case 34, 47, 92, 98, 102, 110, 114, 116, 117 -> true;
-        default -> false;
+            case 34, 47, 92, 98, 102, 110, 114, 116, 117 -> true;
+            default -> false;
+        };
+    }
+
+    private static int getCodePointForEscapableDelim(final int codePoint) {
+        // for better performance, case is the integers in
+        // JSON_STRING_ESCAPABLE_DELIMS_SORTED_ASC
+        //Note: \" i.e. \34 = JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT
+        return switch (codePoint) {
+            case 34 -> JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT;
+            case 47 -> FORWARD_SLASH_CODE_POINT;
+            case 92 -> SLASH_SLASH_CODE_POINT;
+            case 98 -> SLASH_B_CODE_POINT;
+            case 102 -> SLASH_F_CODE_POINT;
+            case 110 -> JsonCodePointUtil.SLASH_N_CODE_POINT;
+            case 114 -> JsonCodePointUtil.SLASH_R_CODE_POINT;
+            case 116 -> SLASH_T_CODE_POINT;
+            default -> codePoint;
         };
     }
 
     static void writeJsonKeyValue(final OutputStream outputStream, final Charset charset, final boolean flushOnWrite,
-            final Map.Entry<String, Object> entry) throws IOException {
+                                  final Map.Entry<String, Object> entry) throws IOException {
         final byte[] charBytes = ":\"".getBytes(charset);
         final byte colon = charBytes[0];
         final byte doubleQuotes = charBytes[1];
         final Object value = entry.getValue();
-        final String key = entry.getKey();
+        final String key = placeEscapeCharInJsonStringValueIfRequired(entry.getKey(), false);
         if (value instanceof final JsonValue jsonValue) {
-            if (JsonValueType.STRING.equals(jsonValue.getValueType())) {
-                outputStream.write(doubleQuotes);
-                outputStream.write(key.getBytes(charset));
-                outputStream.write(doubleQuotes);
-                outputStream.write(colon);
-                outputStream.write(doubleQuotes);
-                outputStream.write(String.valueOf(placeEscapeCharInJsonStringValueIfRequired(jsonValue.asString()))
-                        .getBytes(charset));
-                outputStream.write(doubleQuotes);
-            } else {
-                outputStream.write(doubleQuotes);
-                outputStream.write(key.getBytes(charset));
-                outputStream.write(doubleQuotes);
-                outputStream.write(colon);
-                outputStream.write(String.valueOf(jsonValue.asString()).getBytes(charset));
-            }
+            outputStream.write(doubleQuotes);
+            outputStream.write(key.getBytes(charset));
+            outputStream.write(doubleQuotes);
+            outputStream.write(colon);
+            outputStream.write(jsonValue.toJsonString().getBytes(charset));
             if (flushOnWrite) {
                 outputStream.flush();
             }
@@ -84,9 +110,7 @@ final class JsonStringUtil {
             outputStream.write(key.getBytes(charset));
             outputStream.write(doubleQuotes);
             outputStream.write(colon);
-            outputStream.write(doubleQuotes);
-            outputStream.write(placeEscapeCharInJsonStringValueIfRequired(s).getBytes(charset));
-            outputStream.write(doubleQuotes);
+            outputStream.write(placeEscapeCharInJsonStringValueIfRequired(s, true).getBytes(charset));
             if (flushOnWrite) {
                 outputStream.flush();
             }
@@ -115,23 +139,15 @@ final class JsonStringUtil {
     }
 
     static void writeJsonValue(final OutputStream outputStream, final Charset charset, final boolean flushOnWrite,
-            final Object value) throws IOException {
+                               final Object value) throws IOException {
         if (value instanceof final JsonValue jsonValue) {
-            final String s = jsonValue.asString();
-            if (s == null) {
-                outputStream.write("null".getBytes(charset));
-            } else if (JsonValueType.STRING.equals(jsonValue.getValueType())) {
-                outputStream.write(
-                        "\"".concat(placeEscapeCharInJsonStringValueIfRequired(s)).concat("\"").getBytes(charset));
-            } else {
-                outputStream.write(s.getBytes(charset));
-            }
+            outputStream.write(jsonValue.toJsonString().getBytes(charset));
             if (flushOnWrite) {
                 outputStream.flush();
             }
         } else if (value instanceof final String s) {
             outputStream
-                    .write("\"".concat(placeEscapeCharInJsonStringValueIfRequired(s)).concat("\"").getBytes(charset));
+                    .write(placeEscapeCharInJsonStringValueIfRequired(s, true).getBytes(charset));
             if (flushOnWrite) {
                 outputStream.flush();
             }
@@ -157,17 +173,10 @@ final class JsonStringUtil {
 
     private static String buildJsonValue(final Object value, final boolean parallel) {
         if (value instanceof final JsonValue jsonValue) {
-            final String s = jsonValue.asString();
-            if (s == null) {
-                return "null";
-            }
-            if (JsonValueType.STRING.equals(jsonValue.getValueType())) {
-                return "\"".concat(placeEscapeCharInJsonStringValueIfRequired(s)).concat("\"");
-            }
-            return s;
+            return jsonValue.toJsonString();
         }
         if (value instanceof final String s) {
-            return "\"".concat(placeEscapeCharInJsonStringValueIfRequired(s)).concat("\"");
+            return placeEscapeCharInJsonStringValueIfRequired(s, true);
         }
         if (value instanceof final JsonListNode jln) {
             return parallel ? jln.toBigJsonString() : jln.toJsonString();
@@ -188,79 +197,266 @@ final class JsonStringUtil {
 
     private static String buildJsonKeyValue(final Map.Entry<String, Object> entry, final boolean parallel) {
         final Object value = entry.getValue();
-        final String key = entry.getKey();
+        final String key = placeEscapeCharInJsonStringValueIfRequired(entry.getKey(), false);
         if (value instanceof final JsonValue jsonValue) {
-            if (JsonValueType.STRING.equals(jsonValue.getValueType())) {
-                return "\"%s\":\"%s\"".formatted(key, placeEscapeCharInJsonStringValueIfRequired(jsonValue.asString()));
-            }
-            return "\"%s\":%s".formatted(key, jsonValue.asString());
+            return buildKeyColonValue(key, jsonValue.toJsonString());
         }
         if (value instanceof final String s) {
-            return "\"%s\":\"%s\"".formatted(key, placeEscapeCharInJsonStringValueIfRequired(s));
+            return buildKeyColonValue(key, placeEscapeCharInJsonStringValueIfRequired(s, true));
         }
         if (value instanceof final JsonListNode jln) {
-            return "\"%s\":%s".formatted(key, jln.toJsonString());
+            return buildKeyColonValue(key, jln.toJsonString());
         }
         if (value instanceof final JsonMapNode jmn) {
-            return "\"%s\":%s".formatted(key, parallel ? jmn.toBigJsonString() : jmn.toJsonString());
+            return buildKeyColonValue(key, parallel ? jmn.toBigJsonString() : jmn.toJsonString());
         }
-        return "\"%s\":%s".formatted(key, value);
+        return buildKeyColonValue(key, String.valueOf(value));
     }
 
-    private static String placeEscapeCharInJsonStringValueIfRequired(final String s) {
+    private static String buildKeyColonValue(final String key, final String jsonValue) {
+        return '"' + key + '"' + ':' + jsonValue;
+    }
+
+    static String placeEscapeCharInJsonStringValueIfRequired(final String s) {
         if (s == null || s.isBlank()) {
             return s;
         }
-        final int[] codePoints = s.codePoints().toArray();
-        int replaceableDelimsCount = 0;
-        for (final int codePoint : codePoints) {
-            if (codePoint == JsonCodePointUtil.ESCAPE_CODE_POINT) {
-                replaceableDelimsCount++;
-            }
-        }
-        if (replaceableDelimsCount == 0) {
+        return placeEscapeCharInJsonStringValueIfRequired(s, StringUtil.toCodePoints(s), false);
+    }
+
+    static String placeEscapeCharInJsonStringValueIfRequired(final String s, final boolean surroundByDoubleQuotes) {
+        if (s == null) {
             return s;
         }
-        final StringBuilder sb = new StringBuilder(codePoints.length + replaceableDelimsCount);
+        if (s.isBlank()) {
+            return surroundByDoubleQuotes ? "\"".concat(s).concat("\"") : s;
+        }
+        return placeEscapeCharInJsonStringValueIfRequired(s, StringUtil.toCodePoints(s), surroundByDoubleQuotes);
+    }
+
+    static String placeEscapeCharInJsonStringValueIfRequired(final int[] codePoints, final boolean surroundByDoubleQuotes) {
+        return placeEscapeCharInJsonStringValueIfRequired(null, codePoints, surroundByDoubleQuotes);
+    }
+
+    private static String placeEscapeCharInJsonStringValueIfRequired(final String s, final int[] codePoints, final boolean surroundByDoubleQuotes) {
+        if (codePoints == null) {
+            return null;
+        }
+        if (codePoints.length == 0) {
+            return surroundByDoubleQuotes ? "\"\"" : "";
+        }
+        final int replaceableDelimsCount = countReplaceableDelims(codePoints);
+        if (replaceableDelimsCount == 0) {
+            if (s != null) {
+                return surroundByDoubleQuotes ? "\"".concat(s).concat("\"") : s;
+            }
+            return surroundByDoubleQuotes ? "\"".concat(new String(codePoints, 0, codePoints.length)).concat("\"") : new String(codePoints, 0, codePoints.length);
+        }
+        final int sbLength = surroundByDoubleQuotes ? codePoints.length + replaceableDelimsCount + 2 : codePoints.length + replaceableDelimsCount;
+        final StringBuilder sb = new StringBuilder(sbLength);
+        if (surroundByDoubleQuotes) {
+            sb.append("\"");
+        }
         for (int i = 0; i < codePoints.length; i++) {
             int codePoint = codePoints[i];
             switch (codePoint) {
-            case JsonCodePointUtil.ESCAPE_CODE_POINT -> {
-                sb.appendCodePoint(codePoint);
-                i++;
-                if (i < codePoints.length) {
-                    codePoint = codePoints[i];
-                    if (codePoint == JsonCodePointUtil.U_CODE_POINT) {
-                        if (JsonCodePointUtil.isValidUnicodeEscapeSequence(codePoints, (i - 1), i + 4)) {
+                case JsonCodePointUtil.ESCAPE_CODE_POINT -> {
+                    sb.appendCodePoint(codePoint);
+                    i++;
+                    if (i < codePoints.length) {
+                        codePoint = codePoints[i];
+                        if (codePoint == JsonCodePointUtil.U_CODE_POINT) {
+                            if (JsonCodePointUtil.isValidUnicodeEscapeSequence(codePoints, (i - 1), i + 4)) {
+                                sb.appendCodePoint(codePoint);
+                                sb.appendCodePoint(codePoints[i + 1]);
+                                sb.appendCodePoint(codePoints[i + 2]);
+                                sb.appendCodePoint(codePoints[i + 3]);
+                                sb.appendCodePoint(codePoints[i + 4]);
+                                i += 4;
+                            } else {
+                                sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                                sb.appendCodePoint(codePoint);
+                            }
+                        } else if (JsonStringUtil.isJsonStringEscapableDelim(codePoint)) {
                             sb.appendCodePoint(codePoint);
-                            sb.appendCodePoint(codePoints[i + 1]);
-                            sb.appendCodePoint(codePoints[i + 2]);
-                            sb.appendCodePoint(codePoints[i + 3]);
-                            sb.appendCodePoint(codePoints[i + 4]);
-                            i += 4;
+                            if (codePoint == JsonCodePointUtil.ESCAPE_CODE_POINT) {
+                                final int nextI = i + 1;
+                                final int nextCodePoint = nextI < codePoints.length ? codePoints[nextI] : -1;
+                                if (JsonCodePointUtil.isValidUnicodeEscapeSequence(codePoints, i, i + 5)) {
+                                    sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                                } else if (nextCodePoint != JsonCodePointUtil.U_CODE_POINT
+                                        && nextCodePoint != JsonCodePointUtil.ESCAPE_CODE_POINT
+                                        && JsonStringUtil.isJsonStringEscapableDelim(nextCodePoint)) {
+                                    sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                                } else {
+                                    sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                                    sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                                }
+                            }
                         } else {
                             sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
                             sb.appendCodePoint(codePoint);
                         }
-                    } else if (JsonStringUtil.isJsonStringEscapableDelim(codePoint)) {
-                        sb.appendCodePoint(codePoint);
                     } else {
                         sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                    }
+                }
+                case JsonCodePointUtil.SLASH_R_CODE_POINT -> sb.append("\\r");
+                case JsonCodePointUtil.SLASH_N_CODE_POINT -> sb.append("\\n");
+                case JsonStringUtil.SLASH_B_CODE_POINT -> sb.append("\\b");
+                case JsonStringUtil.SLASH_F_CODE_POINT -> sb.append("\\f");
+                case JsonStringUtil.SLASH_T_CODE_POINT -> sb.append("\\t");
+                case JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT -> {
+                    sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                    sb.appendCodePoint(codePoint);
+                }
+                default -> sb.appendCodePoint(codePoint);
+            }
+        }
+        if (surroundByDoubleQuotes) {
+            sb.append("\"");
+        }
+        return sb.toString();
+    }
+
+    private static int countReplaceableDelims(final int[] codePoints) {
+        int replaceableDelimsCount = 0;
+        for (final int codePoint : codePoints) {
+            switch (codePoint) {
+                case JsonCodePointUtil.ESCAPE_CODE_POINT,
+                     JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT,
+                     JsonCodePointUtil.SLASH_R_CODE_POINT,
+                     JsonCodePointUtil.SLASH_N_CODE_POINT,
+                     SLASH_B_CODE_POINT,
+                     SLASH_F_CODE_POINT,
+                     SLASH_T_CODE_POINT -> replaceableDelimsCount++;
+            }
+        }
+        return replaceableDelimsCount;
+    }
+
+    static String replaceEscapeCharSequenceWithJavaChars(final int[] codePoints, final int startIndex, final int length) {
+        return replaceEscapeCharSequenceWithJavaChars(codePoints, startIndex, length, false);
+    }
+
+    static String replaceEscapeCharSequenceWithJavaChars(final int[] codePoints, final int startIndex, final int length, final boolean parseUnicodeCharSequence) {
+        final int endIndex = startIndex + length - 1;
+        boolean matchFound = false;
+        matchFinderLoop:
+        for (int i = startIndex; i <= endIndex; i++) {
+            switch (codePoints[i]) {
+                case JsonCodePointUtil.ESCAPE_CODE_POINT, JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT -> {
+                    matchFound = true;
+                    break matchFinderLoop;
+                }
+            }
+        }
+        if (!matchFound) {
+            return new String(codePoints, startIndex, length);
+        }
+        final StringBuilder sb = new StringBuilder(length);
+
+        for (int i = startIndex; i <= (endIndex); i++) {
+            int codePoint = codePoints[i];
+            switch (codePoint) {
+                case JsonCodePointUtil.ESCAPE_CODE_POINT -> {
+                    final int prevCodePoint = codePoint;
+                    i++;
+                    if (i <= endIndex) {
+                        codePoint = codePoints[i];
+                        if (codePoint == JsonCodePointUtil.U_CODE_POINT && JsonCodePointUtil.isValidUnicodeEscapeSequence(codePoints, (i - 1), i + 4)) {
+                            if (parseUnicodeCharSequence) {
+                                final StringBuilder unicodeValuePart = new StringBuilder(4);
+                                unicodeValuePart.appendCodePoint(codePoints[i + 1]);
+                                unicodeValuePart.appendCodePoint(codePoints[i + 2]);
+                                unicodeValuePart.appendCodePoint(codePoints[i + 3]);
+                                unicodeValuePart.appendCodePoint(codePoints[i + 4]);
+                                sb.appendCodePoint(Integer.parseInt(unicodeValuePart.toString(), 16));
+                            } else {
+                                sb.appendCodePoint(prevCodePoint);
+                                sb.appendCodePoint(codePoint);
+                                sb.appendCodePoint(codePoints[i + 1]);
+                                sb.appendCodePoint(codePoints[i + 2]);
+                                sb.appendCodePoint(codePoints[i + 3]);
+                                sb.appendCodePoint(codePoints[i + 4]);
+                            }
+                            i += 4;
+                        } else if (JsonStringUtil.startsWithSlashRSlashN(codePoints, (i - 1))) {
+                            sb.append("\r\n");
+                            i += 2;
+                        } else if (JsonStringUtil.isJsonStringEscapableDelim(codePoint)) {
+                            sb.appendCodePoint(getCodePointForEscapableDelim(codePoint));
+                        } else {
+                            sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                            sb.appendCodePoint(codePoint);
+                        }
+                    } else {
+                        sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                    }
+                }
+                case JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT -> {
+                    sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+                    sb.appendCodePoint(codePoint);
+                }
+                default -> sb.appendCodePoint(codePoint);
+            }
+        }
+        return sb.toString();
+    }
+
+    static String toUnicodeCharsDecodedString(final int[] codePoints, final int startIndex, final int length) {
+        final int endIndex = startIndex + length - 1;
+        boolean matchFound = false;
+        for (int i = startIndex; i <= endIndex; i++) {
+            if (codePoints[i] == JsonCodePointUtil.ESCAPE_CODE_POINT) {
+                matchFound = true;
+                break;
+            }
+        }
+        if (!matchFound) {
+            return new String(codePoints, startIndex, length);
+        }
+        final StringBuilder sb = new StringBuilder(length);
+
+        for (int i = startIndex; i <= (endIndex); i++) {
+            int codePoint = codePoints[i];
+            if (codePoint == JsonCodePointUtil.ESCAPE_CODE_POINT) {
+                final int prevCodePoint = codePoint;
+                i++;
+                if (i <= endIndex) {
+                    codePoint = codePoints[i];
+                    if (codePoint == JsonCodePointUtil.U_CODE_POINT && JsonCodePointUtil.isValidUnicodeEscapeSequence(codePoints, (i - 1), i + 4)) {
+                        final StringBuilder unicodeValuePart = new StringBuilder(4);
+                        unicodeValuePart.appendCodePoint(codePoints[i + 1]);
+                        unicodeValuePart.appendCodePoint(codePoints[i + 2]);
+                        unicodeValuePart.appendCodePoint(codePoints[i + 3]);
+                        unicodeValuePart.appendCodePoint(codePoints[i + 4]);
+                        sb.appendCodePoint(Integer.parseInt(unicodeValuePart.toString(), 16));
+                        i += 4;
+                    } else {
+                        sb.appendCodePoint(prevCodePoint);
                         sb.appendCodePoint(codePoint);
                     }
                 } else {
                     sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
                 }
-            }
-            case JsonCodePointUtil.DOUBLE_QUOTES_CODE_POINT -> {
-                sb.appendCodePoint(JsonCodePointUtil.ESCAPE_CODE_POINT);
+            } else {
                 sb.appendCodePoint(codePoint);
             }
-            default -> sb.appendCodePoint(codePoint);
-            }
         }
-
         return sb.toString();
+    }
+
+    private static boolean startsWithSlashRSlashN(final int[] codePoints, final int startIndex) {
+        if ((codePoints.length - startIndex) >= SLASH_R_SLASH_N_CHARS.length) {
+            for (int i = 0; i < SLASH_R_SLASH_N_CHARS.length; i++) {
+                if (codePoints[startIndex + i] != SLASH_R_SLASH_N_CHARS[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonStringValueType.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonStringValueType.java
@@ -30,17 +30,27 @@ public enum JsonStringValueType {
         String parse(final int[] codePoints, final int[] startEndIndices) {
             return JsonCodePointUtil.toString(codePoints, startEndIndices);
         }
+
+        @Override
+        String parse(final int[] codePoints) {
+            return JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(codePoints, 0, codePoints.length);
+        }
     },
 
     /**
-     * To represent JsonValue wrapper object as null value.
+     * To represent JsonValue wrapper object as value.
      *
      * @since 12.0.4
      */
     JSON_VALUE {
         @Override
         JsonValue parse(final int[] codePoints, final int[] startEndIndices) {
-            return new JsonValue(JsonCodePointUtil.cut(codePoints, startEndIndices), JsonValueType.STRING);
+            return new JsonValue(JsonCodePointUtil.cut(codePoints, startEndIndices), JsonValueType.ENCODED_STRING);
+        }
+
+        @Override
+        JsonValue parse(final int[] codePoints) {
+            return new JsonValue(codePoints, JsonValueType.ENCODED_STRING);
         }
     };
 
@@ -50,4 +60,10 @@ public enum JsonStringValueType {
     Object parse(final int[] codePoints, final int[] startEndIndices) {
         throw new AssertionError();
     }
+
+    Object parse(final int[] codePoints) {
+        throw new AssertionError();
+    }
+
+
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonValue.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonValue.java
@@ -15,12 +15,13 @@
  */
 package com.webfirmframework.wffweb.json;
 
+import com.webfirmframework.wffweb.InvalidValueException;
+import com.webfirmframework.wffweb.util.StringUtil;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
-
-import com.webfirmframework.wffweb.InvalidValueException;
 
 /**
  * @param codePoints the code points of string representation of value.
@@ -43,7 +44,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
      * @since 12.0.4
      */
     public JsonValue(final String value, final JsonValueType valueType) {
-        this(value != null ? value.codePoints().toArray() : null, valueType);
+        this(value != null ? StringUtil.toCodePoints(value) : null, valueType);
     }
 
     /**
@@ -62,7 +63,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
      * @since 12.0.4
      */
     public JsonValue(final String value) {
-        this(Objects.requireNonNull(value).codePoints().toArray(), JsonValueType.STRING);
+        this(StringUtil.toCodePoints(Objects.requireNonNull(value)), JsonValueType.STRING);
     }
 
     /**
@@ -72,7 +73,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
      * @since 12.0.4
      */
     public JsonValue(final Number value) {
-        this(Objects.requireNonNull(value).toString().codePoints().toArray(), JsonValueType.NUMBER);
+        this(StringUtil.toCodePoints(Objects.requireNonNull(value).toString()), JsonValueType.NUMBER);
     }
 
     /**
@@ -82,7 +83,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
      * @since 12.0.4
      */
     public JsonValue(final boolean value) {
-        this(String.valueOf(value).codePoints().toArray(), JsonValueType.BOOLEAN);
+        this(StringUtil.toCodePoints(String.valueOf(value)), JsonValueType.BOOLEAN);
     }
 
     @Override
@@ -90,9 +91,13 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
         return codePoints != null ? Arrays.copyOfRange(codePoints, 0, codePoints.length) : null;
     }
 
+    int[] originalCodePoints() {
+        return codePoints;
+    }
+
     /**
      * @return the value as Integer or null. It will throw exception if the value is
-     *         not parsable to Integer.
+     * not parsable to Integer.
      * @since 12.0.4
      */
     public Integer asInteger() {
@@ -104,7 +109,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
 
     /**
      * @return the value as Long or null. It will throw exception if the value is
-     *         not parsable to Long.
+     * not parsable to Long.
      * @since 12.0.4
      */
     public Long asLong() {
@@ -116,7 +121,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
 
     /**
      * @return the value as Double or null. It will throw exception if the value is
-     *         not parsable to Double.
+     * not parsable to Double.
      * @since 12.0.4
      */
     public Double asDouble() {
@@ -128,7 +133,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
 
     /**
      * @return the value as BigDecimal or null. It will throw exception if the value
-     *         is not parsable to BigDecimal.
+     * is not parsable to BigDecimal.
      * @since 12.0.4
      */
     public BigDecimal asBigDecimal() {
@@ -140,7 +145,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
 
     /**
      * @return the value as BigInteger or null. It will throw exception if the value
-     *         is not parsable to BigInteger.
+     * is not parsable to BigInteger.
      * @since 12.0.4
      */
     public BigInteger asBigInteger() {
@@ -152,7 +157,7 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
 
     /**
      * @return the value as Boolean or null. It will throw exception if the value is
-     *         not parsable to Boolean.
+     * not parsable to Boolean.
      * @since 12.0.4
      */
     public Boolean asBoolean() {
@@ -167,16 +172,49 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
     }
 
     /**
+     * This method returns raw JSON string value (i.e. without decoding to Java string) if the object is created by JsonParser.
+     * Use {@link #asString(boolean)} with argument true if the returned string to be JSON decoded value.
+     * Use {@link #asString(boolean)} with arguments (true, true) if the returned string to be JSON decoded value and Unicode chars sequence to be parsed to Java chars.
+     *
      * @return the value as String or null.
      * @since 12.0.4
      */
     public String asString() {
+        return asString(false, false);
+    }
+
+    /**
+     * @param decode true to decode the json string value or false to get the raw text.
+     * @return the value as String or null.
+     * @since 12.0.11
+     */
+    public String asString(final boolean decode) {
+        return asString(decode, false);
+    }
+
+    /**
+     * @param decodeJson                 true to decode the json string value or false to get the raw text.
+     * @param decodeUnicodeCharsSequence true to decode the Unicode chars sequences like <span>\</span><span>u2122</span> to Java chars or false to use as it is.
+     * @return the value as String or null.
+     * @since 12.0.11
+     */
+    public String asString(final boolean decodeJson, final boolean decodeUnicodeCharsSequence) {
         if (codePoints == null) {
             return null;
+        }
+        if (decodeJson) {
+            return JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(codePoints, 0, codePoints.length, decodeUnicodeCharsSequence);
+        } else if (decodeUnicodeCharsSequence) {
+            return JsonStringUtil.toUnicodeCharsDecodedString(codePoints, 0, codePoints.length);
         }
         return new String(codePoints, 0, codePoints.length);
     }
 
+    /**
+     * @return the valueType.
+     * @deprecated use the alternative method {@link #valueType()} which does the same job.
+     */
+    @Deprecated(since = "12.0.11", forRemoval = true)
     public JsonValueType getValueType() {
         return valueType;
     }
@@ -187,14 +225,15 @@ public record JsonValue(int[] codePoints, JsonValueType valueType) implements Js
      */
     @Override
     public String toJsonString() {
-        final String s = asString();
-        if (s == null) {
+        if (codePoints == null) {
             return "null";
         }
         if (JsonValueType.STRING.equals(valueType)) {
-            return "\"".concat(s).concat("\"");
+            return JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(codePoints, true);
+        } else if (JsonValueType.ENCODED_STRING.equals(valueType)) {
+            return "\"".concat(new String(codePoints, 0, codePoints.length)).concat("\"");
         }
-        return s;
+        return new String(codePoints, 0, codePoints.length);
     }
 
     @Override

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonValueType.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/json/JsonValueType.java
@@ -21,7 +21,7 @@ package com.webfirmframework.wffweb.json;
 public enum JsonValueType {
 
     /**
-     * To represent a JSON string value.
+     * To represent a JSON decoded string value.
      */
     STRING,
 
@@ -38,5 +38,11 @@ public enum JsonValueType {
     /**
      * To represent a JSON null value.
      */
-    NULL;
+    NULL,
+
+    /**
+     * To represent a JSON string value which is already encoded to JSON compatible string value.
+     * If the parser creates a JsonValue object it will be this type and object will contain raw text value i.e. without decoding new line, escape chars, Unicode char sequences etc... to Java chars.
+     */
+    ENCODED_STRING
 }

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/lang/UnicodeString.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/lang/UnicodeString.java
@@ -15,12 +15,14 @@
  */
 package com.webfirmframework.wffweb.lang;
 
+import com.webfirmframework.wffweb.util.StringUtil;
+
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.IntStream.Builder;
 
 /**
- * An immutable class for unicode based string manipulation.
+ * An immutable class for Unicode based string manipulation.
  *
  * @author WFF
  * @since 3.0.15
@@ -67,7 +69,7 @@ public final class UnicodeString {
     private int hash;
 
     public UnicodeString(final String s) {
-        this(s != null ? s.codePoints().toArray() : null);
+        this(s != null ? StringUtil.toCodePoints(s) : null);
     }
 
     public UnicodeString(final int[] codePoints) {
@@ -76,7 +78,7 @@ public final class UnicodeString {
     }
 
     /**
-     * @return the number of unicode chars contained in it or -1 if it is a null
+     * @return the number of Unicode chars contained in it or -1 if it is a null
      *         UnicodeString.
      */
     public int length() {
@@ -185,7 +187,7 @@ public final class UnicodeString {
     }
 
     /**
-     * @param c the unicode char code
+     * @param c the Unicode char code
      * @return the index
      * @since 3.0.15
      */
@@ -215,7 +217,7 @@ public final class UnicodeString {
     }
 
     /**
-     * @param c c the unicode char code
+     * @param c c the Unicode char code
      * @return the index from last
      * @since 3.0.15
      */
@@ -238,7 +240,7 @@ public final class UnicodeString {
      * @since 3.0.15
      */
     public UnicodeString replace(final String forString, final String with) {
-        return replace(codePoints, forString.codePoints().toArray(), with.codePoints().toArray());
+        return replace(codePoints, StringUtil.toCodePoints(forString), StringUtil.toCodePoints(with));
     }
 
     /**
@@ -296,7 +298,7 @@ public final class UnicodeString {
     /**
      * @param delim to by which the given string to be split. It is the code point
      *              value of char.
-     * @return the array of UnicodeStrings split by the given unicode char code.
+     * @return the array of UnicodeStrings split by the given Unicode char code.
      * @since 3.0.15
      */
     public UnicodeString[] split(final int delim) {
@@ -305,7 +307,7 @@ public final class UnicodeString {
 
     /**
      * @param delims to by which the given string to be split. It is the code point
-     *               values of chars, i.e. unicode values.
+     *               values of chars, i.e. Unicode values.
      * @return the array of UnicodeStrings split by the given chars.
      * @since 3.0.15
      */

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/util/NumberUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/util/NumberUtil.java
@@ -25,20 +25,27 @@ import java.math.BigInteger;
 public final class NumberUtil {
 
     // length = 11
-    private static final int[] INT_MIN_VALUE_CODE_POINTS = String.valueOf(Integer.MIN_VALUE).codePoints().toArray();
+//    private static final int[] INT_MIN_VALUE_CODE_POINTS = String.valueOf(Integer.MIN_VALUE).codePoints().toArray();
+    private static final int[] INT_MIN_VALUE_CODE_POINTS = { 45, 50, 49, 52, 55, 52, 56, 51, 54, 52, 56 };
 
     // length = 10
-    private static final int[] INT_MAX_VALUE_CODE_POINTS = String.valueOf(Integer.MAX_VALUE).codePoints().toArray();
+//    private static final int[] INT_MAX_VALUE_CODE_POINTS = String.valueOf(Integer.MAX_VALUE).codePoints().toArray();
+    private static final int[] INT_MAX_VALUE_CODE_POINTS = {50, 49, 52, 55, 52, 56, 51, 54, 52, 55};
 
-    private static final int[] LONG_MIN_VALUE_CODE_POINTS = String.valueOf(Long.MIN_VALUE).codePoints().toArray();
+//    private static final int[] LONG_MIN_VALUE_CODE_POINTS = String.valueOf(Long.MIN_VALUE).codePoints().toArray();
+    private static final int[] LONG_MIN_VALUE_CODE_POINTS = { 45, 57, 50, 50, 51, 51, 55, 50, 48, 51, 54, 56, 53, 52, 55, 55, 53, 56, 48, 56 };
 
-    private static final int[] LONG_MAX_VALUE_CODE_POINTS = String.valueOf(Long.MAX_VALUE).codePoints().toArray();
+//    private static final int[] LONG_MAX_VALUE_CODE_POINTS = String.valueOf(Long.MAX_VALUE).codePoints().toArray();
+    private static final int[] LONG_MAX_VALUE_CODE_POINTS = { 57, 50, 50, 51, 51, 55, 50, 48, 51, 54, 56, 53, 52, 55, 55, 53, 56, 48, 55 };
 
-    private static final int[] NUMBER_CODE_POINTS = "0123456789".codePoints().toArray();
+//    private static final int[] NUMBER_CODE_POINTS = "0123456789".codePoints().toArray();
+    private static final int[] NUMBER_CODE_POINTS = { 48, 49, 50, 51, 52, 53, 54, 55, 56, 57 };
 
-    private static final int ZERO_CODE_POINT = NUMBER_CODE_POINTS[0];
+//    private static final int ZERO_CODE_POINT = NUMBER_CODE_POINTS[0];
+    private static final int ZERO_CODE_POINT = 48;
 
-    private static final int NINE_CODE_POINT = NUMBER_CODE_POINTS[NUMBER_CODE_POINTS.length - 1];
+//    private static final int NINE_CODE_POINT = NUMBER_CODE_POINTS[NUMBER_CODE_POINTS.length - 1];
+    private static final int NINE_CODE_POINT = 57;
 
     private NumberUtil() {
         throw new AssertionError();
@@ -192,9 +199,7 @@ public final class NumberUtil {
                 return false;
             }
 
-            final boolean notAStrictNumber = startsWithMinus
-                    ? value.codePoints().skip(1).anyMatch(cp -> cp < ZERO_CODE_POINT || cp > NINE_CODE_POINT)
-                    : value.codePoints().anyMatch(cp -> cp < ZERO_CODE_POINT || cp > NINE_CODE_POINT);
+            final boolean notAStrictNumber = isNotAStrictNumber(value, startsWithMinus);
 
             if (!notAStrictNumber) {
                 if (valueLength == INT_MAX_VALUE_CODE_POINTS.length) {
@@ -213,6 +218,23 @@ public final class NumberUtil {
             }
 
             return !notAStrictNumber;
+        }
+        return false;
+    }
+
+    private static boolean isNotAStrictNumber(final String value, final boolean skipFirst) {
+        boolean skip = skipFirst;
+        final int codePointCount = value.codePointCount(0, value.length());
+        for (int i = 0, j = 0; i < codePointCount; i++) {
+            final int codePoint = value.codePointAt(j);
+            j += Character.charCount(codePoint);
+            if (skip) {
+                skip = false;
+                continue;
+            }
+            if (codePoint < ZERO_CODE_POINT || codePoint > NINE_CODE_POINT) {
+                return true;
+            }
         }
         return false;
     }
@@ -245,9 +267,7 @@ public final class NumberUtil {
                 return false;
             }
 
-            final boolean notAStrictNumber = startsWithMinus
-                    ? value.codePoints().skip(1).anyMatch(cp -> cp < ZERO_CODE_POINT || cp > NINE_CODE_POINT)
-                    : value.codePoints().anyMatch(cp -> cp < ZERO_CODE_POINT || cp > NINE_CODE_POINT);
+            final boolean notAStrictNumber = isNotAStrictNumber(value, startsWithMinus);
 
             if (!notAStrictNumber) {
                 if (valueLength == LONG_MAX_VALUE_CODE_POINTS.length) {

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/util/StringBuilderUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/util/StringBuilderUtil.java
@@ -32,7 +32,7 @@ public final class StringBuilderUtil {
      * @return
      * @author WFF
      * @since 1.0.0 initial implementation.
-     * @since 3.0.15 It is unicode aware.
+     * @since 3.0.15 It is Unicode aware.
      *
      */
     public static String getTrimmedString(final StringBuilder sb) {
@@ -77,7 +77,7 @@ public final class StringBuilderUtil {
      * @return
      * @author WFF
      * @since 1.0.0 initial implementation.
-     * @since 3.0.15 It is unicode aware.
+     * @since 3.0.15 It is Unicode aware.
      *
      */
     @SuppressWarnings("unused")

--- a/wffweb/src/main/java/com/webfirmframework/wffweb/util/StringUtil.java
+++ b/wffweb/src/main/java/com/webfirmframework/wffweb/util/StringUtil.java
@@ -76,7 +76,7 @@ public final class StringUtil {
      *
      * @param input the string to convert
      * @return the converted string having a single space in between characters.
-     * @since 3.0.15 it is unicode aware
+     * @since 3.0.15 it is Unicode aware
      */
     public static String convertSpacesToSingleSpace(final String input) {
 
@@ -88,7 +88,7 @@ public final class StringUtil {
 
         int prevCP = 0;
         boolean zerothIndex = true;
-        final int[] codePoints = input.codePoints().toArray();
+        final int[] codePoints = toCodePoints(input);
 
         for (final int c : codePoints) {
             if (zerothIndex || prevCP != SPACE_CODE_POINT || c != SPACE_CODE_POINT) {
@@ -115,7 +115,7 @@ public final class StringUtil {
      *
      * @param input the string to convert
      * @return the converted string having a single space in between characters.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      */
     public static String convertWhitespacesToSingleSpace(final String input) {
 
@@ -128,7 +128,7 @@ public final class StringUtil {
         int prevCP = 0;
         boolean zerothIndex = true;
 
-        final int[] codePoints = input.codePoints().toArray();
+        final int[] codePoints = toCodePoints(input);
         for (final int c : codePoints) {
             final boolean ws = isWhitespace(c);
 
@@ -160,7 +160,7 @@ public final class StringUtil {
      *
      * @param input
      * @return the string without spaces.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      */
     public static String removeSpaces(final String input) {
         if (input.length() == 0) {
@@ -169,7 +169,7 @@ public final class StringUtil {
 
         final StringBuilder builder = new StringBuilder(input.length());
 
-        final int[] codePoints = input.codePoints().toArray();
+        final int[] codePoints = toCodePoints(input);
         for (final int c : codePoints) {
             if (c != SPACE_CODE_POINT) {
                 builder.appendCodePoint(c);
@@ -185,7 +185,7 @@ public final class StringUtil {
      *
      * @param input
      * @return the string without spaces.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      */
     public static String removeWhitespaces(final String input) {
 
@@ -195,7 +195,7 @@ public final class StringUtil {
 
         final StringBuilder builder = new StringBuilder(input.length());
 
-        final int[] codePoints = input.codePoints().toArray();
+        final int[] codePoints = toCodePoints(input);
         for (final int c : codePoints) {
             if (!isWhitespace(c)) {
                 builder.appendCodePoint(c);
@@ -211,7 +211,7 @@ public final class StringUtil {
      * @param input
      * @param codePoints
      * @return the string without spaces.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      */
     @SuppressWarnings("unused")
     private static String removeCodePoints(final String input, final int[] codePoints) {
@@ -222,7 +222,7 @@ public final class StringUtil {
 
         final StringBuilder builder = new StringBuilder(input.length());
 
-        final int[] codePointsAry = input.codePoints().toArray();
+        final int[] codePointsAry = toCodePoints(input);
         for (final int c : codePointsAry) {
 
             boolean remove = false;
@@ -684,7 +684,7 @@ public final class StringUtil {
      * @param value
      * @return true if the given value is starting with a white space
      * @since 2.1.8 initial implementation.
-     * @since 3.0.15 unicode aware.
+     * @since 3.0.15 Unicode aware.
      */
     public static boolean startsWithWhitespace(final String value) {
         if (value.length() == 0) {
@@ -705,7 +705,7 @@ public final class StringUtil {
      * @param value
      * @return true if the given value is ending with a white space
      * @since 2.1.8 initial implementation.
-     * @since 3.0.15 unicode aware.
+     * @since 3.0.15 Unicode aware.
      */
     public static boolean endsWithWhitespace(final String value) {
         if (value.length() == 0) {
@@ -718,7 +718,7 @@ public final class StringUtil {
         // works but not sure about the performance cost.
 //      return isWhitespace(value.codePoints().reduce((first, second) -> second).getAsInt());
 
-        final int[] codePoints = value.codePoints().toArray();
+        final int[] codePoints = toCodePoints(value);
         return isWhitespace(codePoints[codePoints.length - 1]);
     }
 
@@ -727,7 +727,7 @@ public final class StringUtil {
      * @param delim  to by which the given string to be split.
      * @return the array of strings split by the given char.
      * @since 3.0.0 public
-     * @since 3.0.15 unicode aware.
+     * @since 3.0.15 Unicode aware.
      */
     public static String[] split(final String string, final char delim) {
 
@@ -767,7 +767,7 @@ public final class StringUtil {
             return new String[] { string };
         }
 
-        final int[] codePoints = string.codePoints().toArray();
+        final int[] codePoints = toCodePoints(string);
 
         final int[] delimPositionInit = new int[codePoints.length];
 
@@ -903,7 +903,7 @@ public final class StringUtil {
         if (string.length() == 0) {
             return false;
         }
-        final int[] codePoints = string.codePoints().toArray();
+        final int[] codePoints = toCodePoints(string);
         return codePoints[codePoints.length - 1] == c;
     }
 
@@ -971,14 +971,14 @@ public final class StringUtil {
      * @param string
      * @return true if the given string contains space char.
      * @since 3.0.1 initial implementation.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      */
     public static boolean containsWhitespace(final String string) {
         if (string.length() == 0) {
             return false;
         }
 
-        final int[] codePoints = string.codePoints().toArray();
+        final int[] codePoints = toCodePoints(string);
 
         for (int i = 0; i < codePoints.length; i++) {
             if (isWhitespace(codePoints[i])) {
@@ -1130,7 +1130,7 @@ public final class StringUtil {
      * @return true if the given string doesn't contain any char other than
      *         whitespace.
      * @since 3.0.1 initial implementation.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      * @since 12.0.0-beta.3 it is String.isBlank.
      */
     public static boolean isBlank(final String s) {
@@ -1156,7 +1156,7 @@ public final class StringUtil {
      * @param s
      * @return the striped string
      * @since 3.0.1 initial implementation.
-     * @since 3.0.15 it is unicode aware.
+     * @since 3.0.15 it is Unicode aware.
      * @since 12.0.0-beta.3 it is String.strip.
      */
     public static String strip(final String s) {
@@ -1203,7 +1203,7 @@ public final class StringUtil {
      * @since 3.0.15
      */
     public static String replace(final String s, final String it, final String with) {
-        return replace(s, it.codePoints().toArray(), with);
+        return replace(s, toCodePoints(it), with);
     }
 
     /**
@@ -1220,7 +1220,7 @@ public final class StringUtil {
             return s;
         }
 
-        final int[] codePoints = s.codePoints().toArray();
+        final int[] codePoints = toCodePoints(s);
 
         if (codePoints.length == codePointsSequence.length && Arrays.equals(codePoints, codePointsSequence)) {
             return with;
@@ -1292,7 +1292,7 @@ public final class StringUtil {
             return new String[] { string };
         }
 
-        final int[] codePoints = string.codePoints().toArray();
+        final int[] codePoints = toCodePoints(string);
 
         int[] delimPositionInit = new int[codePoints.length];
 
@@ -1347,6 +1347,60 @@ public final class StringUtil {
         }
 
         return splittedStrings;
+    }
+
+    /**
+     * @param string the input string.
+     * @return the code points array from the string.
+     * @since 12.0.11
+     */
+    public static int[] toCodePoints(final String string) {
+        final int length = string.length();
+        if (length == 0) {
+            return new int[0];
+        }
+        final int[] codePoints = new int[string.codePointCount(0, length)];
+        for (int i = 0, j = 0; i < codePoints.length; i++) {
+            final int codePoint = string.codePointAt(j);
+            codePoints[i] = codePoint;
+            j += Character.charCount(codePoint);
+        }
+        return codePoints;
+    }
+
+    /**
+     * For future dev.
+     * @param string the input string.
+     * @param startIndex the beginning code point index, inclusive. It is NOT char index.
+     * @param exclusiveEndIndex the ending code point index, exclusive. It is NOT char index.
+     * @return the substring.
+     * @since 12.0.11
+     */
+    static String substringByCodePointIndices(final String string, final int startIndex, final int exclusiveEndIndex) {
+        final int a = string.offsetByCodePoints(0, startIndex);
+        return string.substring(a, string.offsetByCodePoints(a, exclusiveEndIndex - startIndex));
+    }
+
+    /**
+     * For future dev.
+     * @param string the input string
+     * @param startIndex the beginning index, inclusive. It is NOT char index.
+     * @param exclusiveEndIndex the ending index, exclusive. It is NOT char index.
+     * @return the substring code points.
+     * @since 12.0.11
+     */
+    static int[] subcodePointsByCodePointIndices(final String string, final int startIndex, final int exclusiveEndIndex) {
+        final int length = exclusiveEndIndex - startIndex;
+        if (length == 0) {
+            return new int[0];
+        }
+        final int[] codePoints = new int[length];
+        for (int i = 0, j = string.offsetByCodePoints(0, startIndex); i < codePoints.length; i++) {
+            final int codePoint = string.codePointAt(j);
+            codePoints[i] = codePoint;
+            j += Character.charCount(codePoint);
+        }
+        return codePoints;
     }
 
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/common/test/AllTests.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/common/test/AllTests.java
@@ -234,7 +234,8 @@ import com.webfirmframework.wffweb.wffbm.data.WffBMObjectTest;
         SharedObjectIdGeneratorTest.class, WhenURIUseCaseTest.class, URIUtilTest.class, EventInitiatorTest.class,
         ImmutableCustomAttributeTest.class, BrowserPageActionTest.class, WffConfigurationTest.class,
         TagContentTest.class, WffBMObjectTest.class, WffBMArrayTest.class, TagCompressedWffBMBytesParserTest.class,
-        JsonCodePointUtilTest.class, JsonListTest.class, JsonMapTest.class, JsonParserTest.class, JsonValueTest.class })
+        JsonCodePointUtilTest.class, JsonListTest.class, JsonMapTest.class, JsonParserTest.class, JsonValueTest.class,
+        JsonMapNodeTest.class, JsonListNodeTest.class, JsonStringUtilTest.class})
 public class AllTests {
 
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonListNodeTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonListNodeTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright since 2014 Web Firm Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webfirmframework.wffweb.json;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class JsonListNodeTest {
+
+    @Test
+    public void testConvertTo() {
+        class CustomJsonMap extends JsonLinkedMap {
+        }
+        class CustomJsonList extends JsonList {
+        }
+
+        JsonList jsonList1 = new JsonList();
+        jsonList1.add("one");
+        jsonList1.add("two");
+        jsonList1.add(3);
+        jsonList1.add(true);
+        jsonList1.add(null);
+
+        JsonLinkedMap jsonMap = new  JsonLinkedMap();
+        jsonMap.put("number", new JsonValue("14", JsonValueType.NUMBER));
+        jsonMap.put("string", new JsonValue("string value", JsonValueType.STRING));
+        jsonMap.put("bool", new JsonValue("true", JsonValueType.BOOLEAN));
+        jsonMap.put("fornull", new JsonValue());
+        jsonList1.add(jsonMap);
+
+        JsonMap subMap = new JsonMap();
+        subMap.put("subMapNumber", 1);
+        subMap.put("subMapString", "string");
+        subMap.put("subMapBoolean", true);
+        jsonMap.put("subMap", subMap);
+
+        JsonList jsonList2 = new JsonList();
+        jsonList2.add("one");
+        jsonList2.add("two");
+        jsonList2.add(3);
+        jsonList2.add(true);
+        jsonList2.add(null);
+        subMap.put("jsonList2", jsonList2);
+
+        final CustomJsonList convertedObject1 = jsonList1.convertTo(
+                CustomJsonMap::new, CustomJsonMap::put,
+                CustomJsonList::new, CustomJsonList::add, true);
+
+        Assert.assertEquals("""
+                ["one","two",3,true,null,{"number":14,"string":"string value","bool":true,"fornull":null,"subMap":{"subMapString":"string","subMapBoolean":true,"subMapNumber":1,"jsonList2":["one","two",3,true,null]}}]
+                """.trim(), convertedObject1.toJsonString());
+
+        Assert.assertEquals(CustomJsonMap.class, convertedObject1.getValueAsJsonMapNode(5).getClass());
+
+        Assert.assertEquals(CustomJsonMap.class, convertedObject1.getValueAsJsonMapNode(5).getValueAsJsonMapNode("subMap").getClass());
+        Assert.assertEquals(CustomJsonList.class, convertedObject1.getValueAsJsonMapNode(5).getValueAsJsonMapNode("subMap").getValueAsJsonListNode("jsonList2").getClass());
+
+
+        Assert.assertEquals("""
+                {"number":14,"string":"string value","bool":true,"fornull":null,"subMap":{"subMapString":"string","subMapBoolean":true,"subMapNumber":1,"jsonList2":["one","two",3,true,null]}}""", convertedObject1.getValueAsJsonMapNode(5).toJsonString());
+
+
+        Assert.assertEquals("""
+                {"subMapString":"string","subMapBoolean":true,"subMapNumber":1,"jsonList2":["one","two",3,true,null]}""", convertedObject1.getValueAsJsonMapNode(5).getValueAsJsonMapNode("subMap").toJsonString());
+        Assert.assertEquals("""
+                ["one","two",3,true,null]""", convertedObject1.getValueAsJsonMapNode(5).getValueAsJsonMapNode("subMap").getValueAsJsonListNode("jsonList2").toJsonString());
+    }
+
+}

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonMapNodeTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonMapNodeTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright since 2014 Web Firm Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.webfirmframework.wffweb.json;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+public class JsonMapNodeTest {
+
+    @Test
+    public void testConvertTo() {
+        class CustomJsonMap extends JsonLinkedMap {
+        }
+        class CustomList extends JsonList {
+
+        }
+        JsonLinkedMap jsonMap = new  JsonLinkedMap();
+        jsonMap.put("number", new JsonValue("14", JsonValueType.NUMBER));
+        jsonMap.put("string", new JsonValue("string value", JsonValueType.STRING));
+        jsonMap.put("bool", new JsonValue("true", JsonValueType.BOOLEAN));
+        jsonMap.put("fornull", new JsonValue());
+        JsonList jsonList1 = new JsonList();
+        jsonList1.add("one");
+        jsonList1.add("two");
+        jsonList1.add(3);
+        jsonList1.add(true);
+        jsonList1.add(null);
+        jsonMap.put("jsonList1", jsonList1);
+
+        JsonMap subMap = new JsonMap();
+        subMap.put("subMapNumber", 1);
+        subMap.put("subMapString", "string");
+        subMap.put("subMapBoolean", true);
+        jsonMap.put("subMap", subMap);
+
+        JsonList jsonList2 = new JsonList();
+        jsonList2.add("one");
+        jsonList2.add("two");
+        jsonList2.add(3);
+        jsonList2.add(true);
+        jsonList2.add(null);
+        subMap.put("jsonList2", jsonList2);
+
+
+        CustomJsonMap convertedObject1 = jsonMap.convertTo(
+                CustomJsonMap::new, CustomJsonMap::put,
+                CustomList::new, CustomList::add, true);
+
+        Assert.assertEquals(CustomList.class, convertedObject1.getValueAsJsonListNode("jsonList1").getClass());
+        Assert.assertEquals(CustomList.class, convertedObject1.getValueAsJsonMapNode("subMap").getValueAsJsonListNode("jsonList2").getClass());
+
+        Assert.assertEquals("{\"number\":14,\"string\":\"string value\",\"bool\":true,\"fornull\":null,\"jsonList1\":[\"one\",\"two\",3,true,null],\"subMap\":{\"subMapString\":\"string\",\"subMapBoolean\":true,\"subMapNumber\":1,\"jsonList2\":[\"one\",\"two\",3,true,null]}}", convertedObject1.toJsonString());
+        Assert.assertEquals(CustomList.class, convertedObject1.getValueAsJsonListNode("jsonList1").getClass());
+
+        Assert.assertTrue(convertedObject1.get("string") instanceof String);
+        Assert.assertEquals("string value", convertedObject1.getValueAsString("string"));
+
+        Assert.assertTrue(convertedObject1.get("number") instanceof Integer);
+        Assert.assertEquals(new BigDecimal("14"), convertedObject1.getValueAsBigDecimal("number"));
+
+
+        jsonMap.put("number", new JsonValue("2147483648", JsonValueType.NUMBER));
+        convertedObject1 = jsonMap.convertTo(
+                CustomJsonMap::new, CustomJsonMap::put,
+                CustomList::new, CustomList::add, true);
+        Assert.assertTrue(convertedObject1.get("number") instanceof Long);
+        Assert.assertEquals(2147483648L, convertedObject1.getValueAsLong("number").longValue());
+        Assert.assertEquals(new BigDecimal("2147483648"), convertedObject1.getValueAsBigDecimal("number"));
+
+        jsonMap.put("number", new JsonValue("2147483648.1401", JsonValueType.NUMBER));
+        convertedObject1 = jsonMap.convertTo(
+                CustomJsonMap::new, CustomJsonMap::put,
+                CustomList::new, CustomList::add, true);
+        Assert.assertTrue(convertedObject1.get("number") instanceof BigDecimal);
+        Assert.assertEquals(new BigDecimal("2147483648.1401"), convertedObject1.getValueAsBigDecimal("number"));
+        Assert.assertEquals(new BigDecimal("2147483648.1401"), convertedObject1.getValueAsJsonValue("number").asBigDecimal());
+
+        jsonMap.put("number", new JsonValue("14", JsonValueType.NUMBER));
+        convertedObject1 = jsonMap.convertTo(
+                CustomJsonMap::new, CustomJsonMap::put,
+                CustomList::new, CustomList::add, true);
+
+        Assert.assertTrue(convertedObject1.get("bool") instanceof Boolean);
+        Assert.assertTrue(convertedObject1.getValueAsBoolean("bool"));
+
+        Assert.assertNull(convertedObject1.get("fornull"));
+
+
+        final CustomJsonMap convertedObject2 = jsonMap.convertTo(
+                CustomJsonMap::new, CustomJsonMap::put,
+                CustomList::new, CustomList::add, false);
+
+        Assert.assertTrue(convertedObject2.get("string") instanceof JsonValue);
+        Assert.assertEquals("string value", convertedObject2.getValueAsString("string"));
+        Assert.assertEquals("string value", convertedObject2.getValueAsJsonValue("string").asString());
+
+        Assert.assertTrue(convertedObject2.get("number") instanceof JsonValue);
+        Assert.assertEquals(new BigDecimal("14"), convertedObject2.getValueAsBigDecimal("number"));
+        Assert.assertEquals(new BigDecimal("14"), convertedObject2.getValueAsJsonValue("number").asBigDecimal());
+
+        Assert.assertTrue(convertedObject2.get("bool") instanceof JsonValue);
+        Assert.assertTrue(convertedObject2.getValueAsBoolean("bool"));
+        Assert.assertTrue(convertedObject2.getValueAsJsonValue("bool").asBoolean());
+
+        Assert.assertTrue(convertedObject2.get("fornull") instanceof JsonValue);
+        Assert.assertNull(convertedObject1.getValueAsJsonValue("fornull").asString());
+        Assert.assertNotNull(convertedObject2.get("fornull"));
+    }
+
+}

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonMapTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonMapTest.java
@@ -30,7 +30,10 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Objects;
 
 public class JsonMapTest {
 
@@ -87,19 +90,17 @@ public class JsonMapTest {
                    "unicode": "𝒜𝒷𝒸𝒹",
                    "large_number": 1.7976931348623157e+308,
                    "negative_number": -0.000123,
-                   "escaped_unicode": "\uD83D\uDE80 \\uWXYZ"
+                   "escaped_unicode": "\uD83D\uDE80 \\u2122"
                  }
                 """;
         JsonMapNode jsonMap = JsonParser.newBuilder().jsonObjectType(JsonObjectType.JSON_MAP).validateEscapeSequence(false).build().parseJsonObject(json) instanceof JsonMapNode mapNode ? mapNode : null;
         Assert.assertNotNull(jsonMap);
-        Assert.assertEquals("Hello, World!\\nNew Line • Bullet", jsonMap.getValueAsString("string"));
-        Assert.assertEquals(" \\\" \\\\ / \\b \\f \\n \\r \\t \\/ ", jsonMap.getValueAsString("special_chars"));
-        String value = jsonMap.getValueAsString("escaped_unicode");
-        Assert.assertEquals("\uD83D\uDE80 \\uWXYZ", value);
-        System.out.println("Arrays.toString(value.codePoints().toArray()) = " + Arrays.toString(value.codePoints().toArray()));
-        System.out.println("jsonMap.toJsonString = " + jsonMap.toJsonString());
+        Assert.assertEquals("Hello, World!\nNew Line • Bullet", jsonMap.getValueAsString("string"));
+        Assert.assertEquals(" \" \\ / \b \f \n \r \t / ", jsonMap.getValueAsString("special_chars"));
+        Assert.assertEquals("\uD83D\uDE80 \\u2122", jsonMap.getValueAsString("escaped_unicode"));
+        Assert.assertEquals("\uD83D\uDE80 \u2122", jsonMap.getValueAsString("escaped_unicode", true));
 
-        Assert.assertEquals("{\"string\":\"Hello, World!\\nNew Line • Bullet\",\"escaped_unicode\":\"\uD83D\uDE80 \\\\uWXYZ\",\"null_value\":null,\"empty_object\":{},\"negative_number\":-0.000123,\"nested_object\":{\"level1\":{\"level2\":{\"level3\":{\"key\":\"value\"}}}},\"special_chars\":\" \\\" \\\\ / \\b \\f \\n \\r \\t \\/ \",\"nested_array\":[[[[[\"deep\"]]]]],\"number\":12345678901234567890,\"empty_array\":[],\"boolean_false\":false,\"mixed_array\":[123,\"text\",true,null,{\"key\":\"value\"},[1,2,3]],\"unicode\":\"\uD835\uDC9C\uD835\uDCB7\uD835\uDCB8\uD835\uDCB9\",\"large_number\":1.7976931348623157E+308,\"boolean_true\":true}", jsonMap.toJsonString());
+        Assert.assertEquals("{\"string\":\"Hello, World!\\nNew Line • Bullet\",\"escaped_unicode\":\"\uD83D\uDE80 \\u2122\",\"null_value\":null,\"empty_object\":{},\"negative_number\":-0.000123,\"nested_object\":{\"level1\":{\"level2\":{\"level3\":{\"key\":\"value\"}}}},\"special_chars\":\" \\\" \\\\ / \\b \\f \\n \\r \\t / \",\"nested_array\":[[[[[\"deep\"]]]]],\"number\":12345678901234567890,\"empty_array\":[],\"boolean_false\":false,\"mixed_array\":[123,\"text\",true,null,{\"key\":\"value\"},[1,2,3]],\"unicode\":\"\uD835\uDC9C\uD835\uDCB7\uD835\uDCB8\uD835\uDCB9\",\"large_number\":1.7976931348623157E+308,\"boolean_true\":true}", jsonMap.toJsonString());
         testToOutputStreamAndToBigOutputStream(jsonMap);
 //         Assert.assertEquals(objectMapper.readTree(json), objectMapper.readTree(jsonMap.toString()));
 //         Assert.assertEquals(objectMapper.readTree(json).toString(), objectMapper.readTree(jsonMap.toString()).toString());
@@ -270,21 +271,61 @@ public class JsonMapTest {
         JsonLinkedMap parsed = JsonLinkedMap.parse("""
                 {
                 "key" : "value",
-                "key1" : "value1"
+                "key1" : "value1",
+                "key2:key3" : "value2\nvalue3",
+                "key4": {"key4:1": "line1\nline2"}
                 }
                 """);
         Assert.assertNotNull(parsed);
+        Assert.assertEquals("value", parsed.get("key"));
+        Assert.assertEquals("value1", parsed.get("key1"));
+        Assert.assertEquals("value2\nvalue3", parsed.get("key2:key3"));
+        Assert.assertEquals("line1\nline2", parsed.getValueAsJsonMapNode("key4").getValueAsString("key4:1"));
     }
 
     @Test
     public void testJsonConcurrentMapParse() {
-        JsonConcurrentMap parse = JsonConcurrentMap.parse("""
+        JsonConcurrentMap parsed = JsonConcurrentMap.parse("""
                 {
                 "key" : "value",
-                "key1" : "value1"
+                "key1" : "value1",
+                "key2:key3" : "value2\nvalue3",
+                "key4": {"key4:1": "line1\nline2"}
                 }
                 """);
-        Assert.assertNotNull(parse);
+        Assert.assertNotNull(parsed);
+        Assert.assertEquals("value", parsed.get("key"));
+        Assert.assertEquals("value1", parsed.get("key1"));
+        Assert.assertEquals("value2\nvalue3", parsed.get("key2:key3"));
+        Assert.assertEquals("line1\nline2", parsed.getValueAsJsonMapNode("key4").getValueAsString("key4:1"));
+    }
+
+    @Test
+    public void testJsonJsonConcurrentSkipListMapParse() {
+        final String inputJson = """
+                {
+                "key" : "value",
+                "key1" : "value1",
+                "key2:key3" : "value2\nvalue3",
+                "key4": {"key4:1": "line1\nline2"}
+                }
+                """;
+        JsonConcurrentSkipListMap parsed = JsonConcurrentSkipListMap.parse(inputJson);
+        Assert.assertNotNull(parsed);
+        Assert.assertEquals("value", parsed.get("key"));
+        Assert.assertEquals("value1", parsed.get("key1"));
+        Assert.assertEquals("value2\nvalue3", parsed.get("key2:key3"));
+        Assert.assertEquals("line1\nline2", parsed.getValueAsJsonMapNode("key4").getValueAsString("key4:1"));
+    }
+
+    @Test
+    public void testJsonMapEscapeChar() throws IOException {
+        String jsonStringFromFile = Files.readString(Path.of(Objects.requireNonNull(JsonListTest.class.getResource("testing_for_escape_char_sequence_json_sample1.json")).getPath())).strip();
+        JsonMap jsonMap = JsonMap.parse(jsonStringFromFile);
+        Assert.assertNotNull(jsonMap);
+        JsonMapNode data = jsonMap.getValueAsJsonMapNode("data");
+        Assert.assertEquals("    \uD83D\uDE80 \u2022 \u00A9 \u2122 ™ \n    ",  data.getValueAsString("escapedUnicode", true));
+        Assert.assertEquals("    \\uD83D\\uDE80 \\u2022 \\u00A9 \\u2122 ™ \n    ",  data.getValueAsString("escapedUnicode"));
     }
 
     @Test
@@ -294,14 +335,16 @@ public class JsonMapTest {
         String value = "{\\\"k\\\":\\\"v\\\"} with \\\\ \\\" ";
         String key = "key4String";
         jsonMap.put(key, value);
-        String expected = """
-                {"%s":"%s"}
-                """.formatted(key, value).strip();
-        Assert.assertEquals(expected, jsonMap.toJsonString());
+
+        Assert.assertEquals("""
+                {"key4String":"{\\"k\\":\\"v\\"} with \\\\\\\\ \\" "}""".strip(), jsonMap.toJsonString());
+        JsonMap newJsonMap = JsonMap.parse(jsonMap.toJsonString());
+        Assert.assertEquals(jsonMap.toJsonString(), newJsonMap.toJsonString());
+
         testToOutputStreamAndToBigOutputStream(jsonMap);
         jsonMap.put("anotherkey", "val\\");
         Assert.assertEquals("""
-                {"anotherkey":"val\\\\","key4String":"{\\"k\\":\\"v\\"} with \\\\ \\" "}
+                {"anotherkey":"val\\\\","key4String":"{\\"k\\":\\"v\\"} with \\\\\\\\ \\" "}
                 """.strip(), jsonMap.toJsonString());
         testToOutputStreamAndToBigOutputStream(jsonMap);
     }
@@ -400,7 +443,7 @@ public class JsonMapTest {
         Assert.assertNotNull(jsonMap);
         WffBMObject wffBMObject = jsonMap.toWffBMObject();
         Assert.assertNotNull(wffBMObject);
-        
+
         Assert.assertEquals(14, wffBMObject.getValueAsInteger("k1").intValue());
         Assert.assertEquals(1, wffBMObject.getValueAsInteger("k2").intValue());
         Assert.assertEquals(19, wffBMObject.getValueAsInteger("k3").intValue());
@@ -429,7 +472,7 @@ public class JsonMapTest {
         Assert.assertNotNull(jsonMap);
         WffBMObject wffBMObject = jsonMap.toWffBMObject();
         Assert.assertNotNull(wffBMObject);
-        
+
         Assert.assertEquals(3000000005L, wffBMObject.getValueAsLong("k1").longValue());
         Assert.assertEquals(3000000004L, wffBMObject.getValueAsLong("k2").longValue());
         Assert.assertEquals(3000000003L, wffBMObject.getValueAsLong("k3").longValue());
@@ -458,7 +501,7 @@ public class JsonMapTest {
         Assert.assertNotNull(jsonMap);
         WffBMObject wffBMObject = jsonMap.toWffBMObject();
         Assert.assertNotNull(wffBMObject);
-        
+
         Assert.assertEquals(14.01D, wffBMObject.getValueAsDouble("k1").doubleValue(), 0);
         Assert.assertEquals(1.19D, wffBMObject.getValueAsDouble("k2").doubleValue(), 0);
         Assert.assertEquals(11.9D, wffBMObject.getValueAsDouble("k3").doubleValue(), 0);
@@ -488,7 +531,7 @@ public class JsonMapTest {
         Assert.assertNotNull(jsonMap);
         WffBMObject wffBMObject = jsonMap.toWffBMObject();
         Assert.assertNotNull(wffBMObject);
-        
+
         Assert.assertEquals(14.01D, wffBMObject.getValueAsBigDecimal("k1").doubleValue(), 0);
         Assert.assertEquals(1.19D, wffBMObject.getValueAsBigDecimal("k2").doubleValue(), 0);
         Assert.assertEquals(11.9D, wffBMObject.getValueAsBigDecimal("k3").doubleValue(), 0);
@@ -596,12 +639,14 @@ public class JsonMapTest {
         //the same with wffweb JsonMap handles it properly
         JsonMap jsonMap = new JsonMap();
         jsonMap.put("k", value);
-        Assert.assertEquals(expectedJson, jsonMap.toJsonString());
+        Assert.assertEquals("{\"k\":\"\\\\\\\\\"}", jsonMap.toJsonString());
+        Assert.assertEquals(JsonLinkedMap.parse(jsonMap.toJsonString()).toJsonString(), jsonMap.toJsonString());
         testToOutputStreamAndToBigOutputStream(jsonMap);
         JsonMap jsonMap1 = new JsonMap();
         jsonMap1.put("k2", "val2");
         jsonMap.put("map", jsonMap1);
-        Assert.assertEquals("{\"k\":\"\\\\\",\"map\":{\"k2\":\"val2\"}}", jsonMap.toJsonString());
+        Assert.assertEquals("{\"k\":\"\\\\\\\\\",\"map\":{\"k2\":\"val2\"}}", jsonMap.toJsonString());
+        Assert.assertEquals(JsonLinkedMap.parse(jsonMap.toJsonString()).toJsonString(), jsonMap.toJsonString());
         testToOutputStreamAndToBigOutputStream(jsonMap);
     }
 
@@ -610,7 +655,7 @@ public class JsonMapTest {
         String json = """
                 {
                   "string" : "Hello, World!\\nNew Line • Bullet",
-                  "escaped_unicode" : "🚀 \\\\WXYZ",
+                  "escaped_unicode" : "🚀 \\u2122",
                   "null_value" : null,
                   "empty_object" : { },
                   "negative_number" : -1.23E-4,
@@ -638,7 +683,6 @@ public class JsonMapTest {
                 """;
 
         JsonMap jsonMap = JsonMap.parse(json);
-
         Assert.assertEquals(objectMapper.readTree(json), objectMapper.readTree(jsonMap.toJsonString()));
         testToOutputStreamAndToBigOutputStream(jsonMap);
 
@@ -683,6 +727,18 @@ public class JsonMapTest {
         System.out.println("(jsonStringDiff - jsonBigStringDiff) = " + (jsonStringDiff - jsonBigStringDiff));
         testToOutputStreamAndToBigOutputStream(jsonMap);
 
+    }
+
+    @Test
+    public void testLargeLong() {
+        String largeLong = "9999" + Long.MAX_VALUE;
+        String inputJson = """
+                {"key": %s}
+                """.formatted(largeLong);
+        JsonMap jsonMap = JsonMap.parse(inputJson);
+        Object o = jsonMap.get("key");
+        Assert.assertTrue(o instanceof BigDecimal);
+        Assert.assertEquals(new BigDecimal(largeLong), o);
     }
 
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonParserTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonParserTest.java
@@ -242,6 +242,11 @@ public class JsonParserTest {
         Assert.assertNotNull(parsedValue);
         Assert.assertFalse((Boolean) parsedValue);
 
+        parsedValue = jsonParser.parseJson("\"string_value\"");
+        Assert.assertNotNull(parsedValue);
+        Assert.assertTrue(parsedValue instanceof String);
+        Assert.assertEquals("string_value", parsedValue);
+
         parsedValue = jsonParser.parseJson("14");
         Assert.assertNotNull(parsedValue);
         Assert.assertTrue(parsedValue instanceof BigDecimal);
@@ -753,6 +758,161 @@ public class JsonParserTest {
         JsonNode expected = objectMapper.readTree("[null, 14, 300000.0004, 3000000003, 3000000002, null]");
         Assert.assertEquals(expected, objectMapper.readTree(listNode.toJsonString()));
         testToOutputStreamAndToBigOutputStream(listNode);
+    }
+
+    @Test
+    public void testJsonParserWithJsonValueType2() throws JsonProcessingException {
+
+        String inputJsonString = """
+                {
+                "key_for_string_value": "string_value\\u2122",
+                "key_for_string_array": ["one\\u2122", "two", "three"],
+                "key_for_number_value": 14,
+                "intArray" : [5, 4, 3, 2],
+                "longArray" : [3000000005, 3000000004, 3000000003, 3000000002],
+                "mixedIntLongNumberArray" : [null, 14, 300000.0004, 3000000003, 3000000002, null],
+                "k4imojiVal" : "Hello 🌍筀🍻👻🕻🥻!",
+                "k2" : "v2{}[]",
+                "k4nullable": {"nullAry":[null,null,null,{"k4nl":null}],"k4ObjContainingNull":{"k4nul":null},"k4null":null},
+                "otherItems": ["one:two pair", " some str ", "yes", null]
+                }
+                """;
+        JsonParser jsonParser = JsonParser.newBuilder()
+                .jsonObjectType(JsonObjectType.JSON_MAP)
+                .jsonArrayType(JsonArrayType.JSON_LIST)
+                .jsonStringValueTypeForObject(JsonStringValueType.JSON_VALUE)
+                .jsonStringValueTypeForArray(JsonStringValueType.JSON_VALUE)
+                .jsonNumberValueTypeForObject(JsonNumberValueType.JSON_VALUE)
+                .jsonNumberValueTypeForArray(JsonNumberValueType.JSON_VALUE)
+                .jsonBooleanValueTypeForObject(JsonBooleanValueType.JSON_VALUE)
+                .jsonBooleanValueTypeForArray(JsonBooleanValueType.JSON_VALUE)
+                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE)
+                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE).build();
+
+        JsonMap jsonMap = jsonParser.parseJsonObject(inputJsonString) instanceof JsonMap jsonMapTmp ? jsonMapTmp : null;
+        JsonNode jsonNode = objectMapper.readTree(inputJsonString);
+
+        Assert.assertEquals("""
+                {"mixedIntLongNumberArray":[null,14,300000.0004,3000000003,3000000002,null],"k4nullable":{"nullAry":[null,null,null,{"k4nl":null}],"k4ObjContainingNull":{"k4nul":null},"k4null":null},"key_for_string_value":"string_value\\u2122","key_for_number_value":14,"longArray":[3000000005,3000000004,3000000003,3000000002],"k2":"v2{}[]","k4imojiVal":"Hello 🌍筀🍻👻🕻🥻!","otherItems":["one:two pair"," some str ","yes",null],"key_for_string_array":["one\\u2122","two","three"],"intArray":[5,4,3,2]}
+                """.trim(), jsonMap.toJsonString());
+
+        Assert.assertNotNull(jsonMap.get("key_for_string_value"));
+        Assert.assertTrue(jsonMap.get("key_for_string_value") instanceof JsonValue);
+        if (jsonMap.getValueAsJsonValue("key_for_string_value") instanceof JsonValue) {
+            JsonValue jsonValue = jsonMap.getValueAsJsonValue("key_for_string_value");
+            Assert.assertEquals("string_value\\u2122", jsonValue.asString());
+            Assert.assertEquals("string_value\\u2122", jsonValue.asString(true));
+            Assert.assertEquals("string_value\u2122", jsonValue.asString(true, true));
+
+        } else {
+            Assert.fail("key_for_string_value is not a JsonValue");
+        }
+
+        Assert.assertTrue(jsonMap.get("key_for_string_array") instanceof JsonListNode);
+
+        if (jsonMap.getValueAsJsonListNode("key_for_string_array").getValueAsJsonValue(0) instanceof JsonValue) {
+            JsonValue jsonValue = jsonMap.getValueAsJsonListNode("key_for_string_array").getValueAsJsonValue(0); 
+            Assert.assertEquals("one\\u2122", jsonValue.asString());
+            Assert.assertEquals("one\\u2122", jsonValue.asString(true));
+            Assert.assertEquals("one\u2122", jsonValue.asString(true, true));
+        } else {
+            Assert.fail("key_for_string_array.get(0) is not a JsonValue");
+        }
+
+        Assert.assertNotNull(jsonMap.get("key_for_number_value"));
+        Assert.assertTrue(jsonMap.get("key_for_number_value") instanceof JsonValue);
+        if (jsonMap.getValueAsJsonValue("key_for_number_value") instanceof JsonValue) {
+            JsonValue jsonValue = jsonMap.getValueAsJsonValue("key_for_number_value");
+            Assert.assertEquals(JsonValueType.NUMBER, jsonValue.valueType());
+            Assert.assertEquals(14, jsonValue.asInteger().intValue());
+            Assert.assertEquals("14", jsonValue.asString());
+            Assert.assertEquals("14", jsonValue.asString(true));
+
+        } else {
+            Assert.fail("key_for_number_value is not a JsonValue");
+        }
+
+        Assert.assertTrue(jsonMap.get("intArray") instanceof JsonListNode);
+
+        if (jsonMap.getValueAsJsonListNode("intArray").getValueAsJsonValue(0) instanceof JsonValue) {
+            JsonValue jsonValue = jsonMap.getValueAsJsonListNode("intArray").getValueAsJsonValue(0);
+            Assert.assertEquals(JsonValueType.NUMBER, jsonValue.valueType());
+            Assert.assertEquals(5, jsonValue.asInteger().intValue());
+            Assert.assertEquals("5", jsonValue.asString());
+            Assert.assertEquals("5", jsonValue.asString(true));
+        } else {
+            Assert.fail("intArray.get(0) is not a JsonValue");
+        }
+
+    }
+
+    @Test
+    public void testJsonParserWithJsonValueType3() {
+        String stringValue = "string_value \\\\u2122 \\u2122 \\\\ \\nend";
+        String inputJsonObjectString = """
+                {"key_for_string_value": "%s"}
+                """.formatted(stringValue);
+        JsonParser jsonParser = JsonParser.newBuilder()
+                .jsonObjectType(JsonObjectType.JSON_MAP)
+                .jsonArrayType(JsonArrayType.JSON_LIST)
+                .jsonStringValueTypeForObject(JsonStringValueType.JSON_VALUE)
+                .jsonStringValueTypeForArray(JsonStringValueType.JSON_VALUE)
+                .jsonNumberValueTypeForObject(JsonNumberValueType.JSON_VALUE)
+                .jsonNumberValueTypeForArray(JsonNumberValueType.JSON_VALUE)
+                .jsonBooleanValueTypeForObject(JsonBooleanValueType.JSON_VALUE)
+                .jsonBooleanValueTypeForArray(JsonBooleanValueType.JSON_VALUE)
+                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE)
+                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE).build();
+
+        JsonMap jsonMap = jsonParser.parseJsonObject(inputJsonObjectString) instanceof JsonMap jsonMapTmp ? jsonMapTmp : null;
+        JsonValue jsonValue = jsonMap.getValueAsJsonValue("key_for_string_value");
+        Assert.assertEquals("""
+                {"key_for_string_value":"%s"}""".formatted(jsonValue.asString()), jsonMap.toJsonString());
+
+        jsonMap.put("key_for_string_value", new JsonValue(stringValue, JsonValueType.ENCODED_STRING));
+        Assert.assertEquals("""
+                {"key_for_string_value":"%s"}""".formatted(jsonValue.asString()), jsonMap.toJsonString());
+
+        jsonMap.put("key_for_string_value", new JsonValue(stringValue, JsonValueType.STRING));
+        Assert.assertEquals("""
+                {"key_for_string_value":"%s"}""".formatted(JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(stringValue, false)), jsonMap.toJsonString());
+
+        Assert.assertEquals("""
+                {"key_for_string_value":%s}""".formatted(JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(stringValue, true)), jsonMap.toJsonString());
+
+
+        Assert.assertEquals("\"%s\"".formatted(stringValue), new JsonValue(stringValue, JsonValueType.ENCODED_STRING).toJsonString());
+        Assert.assertEquals("\"string_value \\\\\\u2122 \\u2122 \\\\\\\\ \\nend\"", new JsonValue(stringValue, JsonValueType.STRING).toJsonString());
+    }
+
+    @Test
+    public void testJsonParserWithJsonValueType4() {
+        String stringValue = "string_value \\\\u2122 \\u2122 \\\\ \\nend";
+        String inputJsonObjectString = """
+                ["%s"]
+                """.formatted(stringValue);
+        JsonParser jsonParser = JsonParser.newBuilder()
+                .jsonObjectType(JsonObjectType.JSON_MAP)
+                .jsonArrayType(JsonArrayType.JSON_LIST)
+                .jsonStringValueTypeForObject(JsonStringValueType.JSON_VALUE)
+                .jsonStringValueTypeForArray(JsonStringValueType.JSON_VALUE)
+                .jsonNumberValueTypeForObject(JsonNumberValueType.JSON_VALUE)
+                .jsonNumberValueTypeForArray(JsonNumberValueType.JSON_VALUE)
+                .jsonBooleanValueTypeForObject(JsonBooleanValueType.JSON_VALUE)
+                .jsonBooleanValueTypeForArray(JsonBooleanValueType.JSON_VALUE)
+                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE)
+                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE).build();
+
+        JsonList jsonList = jsonParser.parseJsonArray(inputJsonObjectString) instanceof JsonList jsonListTmp ? jsonListTmp : null;
+        JsonValue jsonValue = jsonList.getValueAsJsonValue(0);
+        Assert.assertEquals("[\"%s\"]".formatted(jsonValue.asString()), jsonList.toJsonString());
+
+        jsonList.set(0, new JsonValue(stringValue, JsonValueType.ENCODED_STRING));
+        Assert.assertEquals("[\"%s\"]".formatted(jsonValue.asString()), jsonList.toJsonString());
+
+        jsonList.set(0, new JsonValue(stringValue, JsonValueType.STRING));
+        Assert.assertEquals("[\"%s\"]".formatted(JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(stringValue, false)), jsonList.toJsonString());
+        Assert.assertEquals("[%s]".formatted(JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(stringValue, true)), jsonList.toJsonString());
     }
 
     @Test

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonStringUtilTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonStringUtilTest.java
@@ -1,0 +1,166 @@
+package com.webfirmframework.wffweb.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class JsonStringUtilTest {
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testPlaceEscapeCharInJsonStringValueIfRequired() throws JsonProcessingException {
+
+        //finished testing
+        String wronglyParsedInObjectMapper = "\\/";
+
+        String jsonValue = """
+                 \\" \\\\ / \\b \\f \\n \\r \\t \\r\\n
+                 """.trim();
+        String json = """
+                {
+                "special_chars": "%s"
+                }
+                """.formatted(jsonValue);
+
+        JsonNode jsonNode = objectMapper.readTree(json);
+
+        Assert.assertEquals(wronglyParsedInObjectMapper, JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(wronglyParsedInObjectMapper));
+        Assert.assertEquals("""
+                \\" \\\\\\\\ / \\b \\f \\n \\r \\t \\r\\n""", JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired(jsonValue));
+
+        Assert.assertEquals(jsonNode.toString(), JsonMap.parse(json).toJsonString());
+
+        String jsonFormat2 = """
+                {"k2" : "v2{\\"k\\":\\"v\\"}[]"}
+                """;
+
+        JsonMap jsonMap = JsonMap.parse(jsonFormat2);
+
+        Assert.assertEquals("""
+                {"k2":"v2{\\"k\\":\\"v\\"}[]"}""".trim(), jsonMap.toJsonString());
+
+        Assert.assertEquals("\\".repeat(2), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\".repeat(1)));
+        Assert.assertEquals("\\".repeat(4), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\".repeat(2)));
+        Assert.assertEquals("\\".repeat(6), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\".repeat(3)));
+        Assert.assertEquals("\\".repeat(8), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\".repeat(4)));
+
+        Assert.assertEquals("\u2122%s\u2122".formatted("\\".repeat(2)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\u2122%s\u2122".formatted("\\".repeat(1))));
+        Assert.assertEquals("\u2122%s\u2122".formatted("\\".repeat(4)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\u2122%s\u2122".formatted("\\".repeat(2))));
+        Assert.assertEquals("\u2122%s\u2122".formatted("\\".repeat(6)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\u2122%s\u2122".formatted("\\".repeat(3))));
+        Assert.assertEquals("\u2122%s\u2122".formatted("\\".repeat(8)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\u2122%s\u2122".formatted("\\".repeat(4))));
+
+        Assert.assertEquals("\\u2122%s\\u2122".formatted("\\".repeat(2)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\u2122%s\\u2122".formatted("\\".repeat(1))));
+        Assert.assertEquals("\\u2122%s\\u2122".formatted("\\".repeat(4)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\u2122%s\\u2122".formatted("\\".repeat(2))));
+        Assert.assertEquals("\\u2122%s\\u2122".formatted("\\".repeat(6)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\u2122%s\\u2122".formatted("\\".repeat(3))));
+        Assert.assertEquals("\\u2122%s\\u2122".formatted("\\".repeat(8)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\u2122%s\\u2122".formatted("\\".repeat(4))));
+
+        Assert.assertEquals("\\b%s\\b".formatted("\\".repeat(2)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\b%s\\b".formatted("\\".repeat(1))));
+        Assert.assertEquals("\\b%s\\b".formatted("\\".repeat(4)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\b%s\\b".formatted("\\".repeat(2))));
+        Assert.assertEquals("\\b%s\\b".formatted("\\".repeat(6)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\b%s\\b".formatted("\\".repeat(3))));
+        Assert.assertEquals("\\b%s\\b".formatted("\\".repeat(8)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("\\b%s\\b".formatted("\\".repeat(4))));
+
+        Assert.assertEquals("start%send".formatted("\\".repeat(2)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("start%send".formatted("\\".repeat(1))));
+        Assert.assertEquals("start%send".formatted("\\".repeat(4)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("start%send".formatted("\\".repeat(2))));
+        Assert.assertEquals("start%send".formatted("\\".repeat(6)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("start%send".formatted("\\".repeat(3))));
+        Assert.assertEquals("start%send".formatted("\\".repeat(8)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("start%send".formatted("\\".repeat(4))));
+
+        Assert.assertEquals("%su%s%su".formatted("\\".repeat(2), "\\".repeat(2), "\\".repeat(2)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("%su%s%su".formatted("\\".repeat(1), "\\".repeat(1), "\\".repeat(1))));
+        Assert.assertEquals("%su%s%su".formatted("\\".repeat(4), "\\".repeat(4), "\\".repeat(4)), JsonStringUtil.placeEscapeCharInJsonStringValueIfRequired("%su%s%su".formatted("\\".repeat(2), "\\".repeat(2), "\\".repeat(2))));
+
+    }
+
+    @Test
+    public void testReplaceEscapeCharSequenceWithJavaChars() throws IOException {
+
+        String escapeCharSequence = "    \\uD83D\\uDE80 \\u2022 \\u00A9 \\u2122 \n    ";
+        int[] codePoints = escapeCharSequence.codePoints().toArray();
+        Assert.assertEquals(escapeCharSequence, JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(codePoints,  0, codePoints.length, false));
+        Assert.assertEquals("    \uD83D\uDE80 \u2022 \u00A9 \u2122 \n    ", JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(codePoints,  0, codePoints.length, true));
+
+        String jsonValue = """
+                 \\" \\\\ / \\b \\f \\n \\r \\t \\/ \\r\\n
+                 """.trim();
+//        jsonValue = "\\u2122 \uD83D\uDE80";
+//        jsonValue = "\\r\\n";
+        String json = """
+                {
+                "special_chars": "%s",
+                "key": "val"
+                }
+                """.formatted(jsonValue);
+
+        JsonNode jsonNode = objectMapper.readTree(json);
+        String specialChars = jsonNode.get("special_chars").asText();
+        codePoints = jsonValue.codePoints().toArray();
+        String actual = JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(codePoints, 0, codePoints.length);
+        Assert.assertEquals(specialChars, actual);
+
+        testReplaceEscapeCharSequenceWithJavaCharsForInput("\\\\", "\\");
+        testReplaceEscapeCharSequenceWithJavaCharsForInput("\\", "\\");
+        testReplaceEscapeCharSequenceWithJavaCharsForInput("\\\\u2122", "\\u2122");
+        testReplaceEscapeCharSequenceWithJavaCharsForInput("\\\\\\u2122", "\\\\u2122");
+        testReplaceEscapeCharSequenceWithJavaCharsForInput("\\\\\\\\u2122", "\\\\u2122");
+    }
+
+    private void testReplaceEscapeCharSequenceWithJavaCharsForInput(String input, String expectedResult) {
+        int[] testCodePoints1 = input.codePoints().toArray();
+        String decoded = JsonStringUtil.replaceEscapeCharSequenceWithJavaChars(testCodePoints1, 0, testCodePoints1.length, false);
+        String msg = "\nInput: %s\nExpected: %s\nActual: %s".formatted(input, expectedResult, decoded);
+        if (!expectedResult.equals(decoded)) {
+            Assert.fail(msg);
+        } else {
+            System.out.println(msg);
+        }
+    }
+
+    @Test
+    public void testToUnicodeCharsDecodedString() {
+        final String input1 = "\\u2122";
+        final String input2 = "\\\\u2122";
+        final int[] codePoints1 = input1.codePoints().toArray();
+        final int[] codePoints2 = input2.codePoints().toArray();
+        Assert.assertEquals("\u2122", JsonStringUtil.toUnicodeCharsDecodedString(codePoints1, 0, codePoints1.length));
+        Assert.assertEquals("™", JsonStringUtil.toUnicodeCharsDecodedString(codePoints1, 0, codePoints1.length));
+        Assert.assertEquals(input2, JsonStringUtil.toUnicodeCharsDecodedString(codePoints2, 0, codePoints2.length));
+
+        final String input3 = "start\\u2122end";
+        final String input4 = "start\\\\u2122end";
+        final int[] codePoints3 = input3.codePoints().toArray();
+        final int[] codePoints4 = input4.codePoints().toArray();
+        Assert.assertEquals("start\u2122end", JsonStringUtil.toUnicodeCharsDecodedString(codePoints3, 0, codePoints3.length));
+        Assert.assertEquals("start™end", JsonStringUtil.toUnicodeCharsDecodedString(codePoints3, 0, codePoints3.length));
+        Assert.assertEquals(input4, JsonStringUtil.toUnicodeCharsDecodedString(codePoints4, 0, codePoints4.length));
+
+        final String input5 = "start\\u2122";
+        final String input6 = "start\\\\u2122";
+        final int[] codePoints5 = input5.codePoints().toArray();
+        final int[] codePoints6 = input6.codePoints().toArray();
+        Assert.assertEquals("start\u2122", JsonStringUtil.toUnicodeCharsDecodedString(codePoints5, 0, codePoints5.length));
+        Assert.assertEquals("start™", JsonStringUtil.toUnicodeCharsDecodedString(codePoints5, 0, codePoints5.length));
+        Assert.assertEquals(input6, JsonStringUtil.toUnicodeCharsDecodedString(codePoints6, 0, codePoints6.length));
+
+        final String input7 = "\\u2122end";
+        final String input8 = "\\\\u2122end";
+        final int[] codePoints7 = input7.codePoints().toArray();
+        final int[] codePoints8 = input8.codePoints().toArray();
+        Assert.assertEquals("\u2122end", JsonStringUtil.toUnicodeCharsDecodedString(codePoints7, 0, codePoints7.length));
+        Assert.assertEquals("™end", JsonStringUtil.toUnicodeCharsDecodedString(codePoints7, 0, codePoints7.length));
+        Assert.assertEquals(input8, JsonStringUtil.toUnicodeCharsDecodedString(codePoints8, 0, codePoints8.length));
+
+        final String input9 = "\n\\u2122\n";
+        final String input10 = "\n\\\\u2122\n";
+        final int[] codePoints9 = input9.codePoints().toArray();
+        final int[] codePoints10 = input10.codePoints().toArray();
+        Assert.assertEquals("\n\u2122\n", JsonStringUtil.toUnicodeCharsDecodedString(codePoints9, 0, codePoints9.length));
+        Assert.assertEquals("\n™\n", JsonStringUtil.toUnicodeCharsDecodedString(codePoints9, 0, codePoints9.length));
+        Assert.assertEquals(input10, JsonStringUtil.toUnicodeCharsDecodedString(codePoints10, 0, codePoints10.length));
+
+    }
+
+}

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonValueTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/json/JsonValueTest.java
@@ -23,11 +23,24 @@ public class JsonValueTest {
     @Test
     public void toJsonString() {
         Assert.assertEquals("\"somevalue\"", new JsonValue("somevalue", JsonValueType.STRING).toJsonString());
+        Assert.assertEquals("\"somevalue \\n \"", new JsonValue("somevalue \\n ", JsonValueType.ENCODED_STRING).toJsonString());
+        Assert.assertEquals("\"\"", new JsonValue("", JsonValueType.STRING).toJsonString());
+        Assert.assertEquals("\"\"", new JsonValue("", JsonValueType.ENCODED_STRING).toJsonString());
         Assert.assertEquals("true", new JsonValue("true", JsonValueType.BOOLEAN).toJsonString());
         Assert.assertEquals("false", new JsonValue("false", JsonValueType.BOOLEAN).toJsonString());
         Assert.assertEquals("14.01", new JsonValue("14.01", JsonValueType.NUMBER).toJsonString());
         Assert.assertEquals("1401", new JsonValue("1401", JsonValueType.NUMBER).toJsonString());
         Assert.assertEquals("null", new JsonValue("null", JsonValueType.NULL).toJsonString());
+        Assert.assertEquals("null", new JsonValue((int[]) null, JsonValueType.NULL).toJsonString());
+        Assert.assertEquals("    \uD83D\uDE80 • © ™    ", new JsonValue("    \uD83D\uDE80 \u2022 \u00A9 \u2122    ", JsonValueType.STRING).asString());
+
+        Assert.assertEquals(" \uD83D\uDE80 • © ™ \nnew line ", new JsonValue(" \uD83D\uDE80 \u2022 \u00A9 \u2122 \nnew line ", JsonValueType.STRING).asString(true));
+        Assert.assertEquals(" \uD83D\uDE80 • © ™ \nnew line \n", new JsonValue(" \uD83D\uDE80 \u2022 \u00A9 \u2122 \nnew line \n", JsonValueType.STRING).asString(true));
+        Assert.assertEquals(" \uD83D\uDE80 • © ™ \nnew line ", new JsonValue(" \uD83D\uDE80 \u2022 \u00A9 \u2122 \\nnew line ", JsonValueType.ENCODED_STRING).asString(true));
+        Assert.assertEquals("\uD83D\uDE80 • © ™ \nnew line \n", new JsonValue("\uD83D\uDE80 \u2022 \u00A9 \u2122 \\nnew line \\n", JsonValueType.ENCODED_STRING).asString(true));
+        Assert.assertEquals("\uD83D\uDE80 • © ™ \nnew line", new JsonValue("\uD83D\uDE80 \u2022 \u00A9 \u2122 \nnew line", JsonValueType.STRING).asString(true));
+        Assert.assertEquals("\n\uD83D\uDE80 • © ™ \nnew line\n", new JsonValue("\\n\uD83D\uDE80 \u2022 \u00A9 \u2122 \\nnew line\\n", JsonValueType.ENCODED_STRING).asString(true));
+        Assert.assertEquals("\n\uD83D\uDE80 • © ™ \nnew line\n", new JsonValue("\\n\uD83D\uDE80 \\u2022 \\u00A9 \\u2122 \\nnew line\\n", JsonValueType.ENCODED_STRING).asString(true, true));
     }
 
 }

--- a/wffweb/src/test/java/com/webfirmframework/wffweb/util/StringUtilTest.java
+++ b/wffweb/src/test/java/com/webfirmframework/wffweb/util/StringUtilTest.java
@@ -21,9 +21,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
+import org.junit.Assert;
 import org.junit.Test;
-
-import com.webfirmframework.wffweb.lang.UnicodeString;
 
 /**
  * @author WFF
@@ -733,6 +732,63 @@ public class StringUtilTest {
         assertEquals("", StringUtil.replace("", "a".codePoints().toArray(), "b"));
         assertEquals("b", StringUtil.replace("", "".codePoints().toArray(), "b"));
         assertEquals("", StringUtil.replace("", "".codePoints().toArray(), ""));
+    }
+
+    @Test
+    public void testToCodePoints() {
+        final String inputString = "abc😀aaaaaaa😀defg";
+        int[] codePoints = StringUtil.toCodePoints(inputString);
+        Assert.assertEquals(inputString, new String(codePoints, 0, codePoints.length));
+        Assert.assertArrayEquals(inputString.codePoints().toArray(), codePoints);
+
+        codePoints = StringUtil.toCodePoints("ab1cd");
+        Assert.assertEquals("ab1cd", new String(codePoints, 0, codePoints.length));
+        Assert.assertArrayEquals("ab1cd".codePoints().toArray(), codePoints);
+
+        codePoints = StringUtil.toCodePoints("");
+        Assert.assertEquals("", new String(codePoints, 0, codePoints.length));
+        Assert.assertArrayEquals("".codePoints().toArray(), codePoints);
+    }
+
+    @Test
+    public void testSubstringByCodePointIndices() {
+        String s = "abc😀def";
+        final int length = Math.toIntExact(s.codePoints().count());
+        Assert.assertNotEquals(s.length(), length);
+        Assert.assertEquals(s, StringUtil.substringByCodePointIndices(s, 0, length));
+        Assert.assertEquals(s.substring(0, s.length()), StringUtil.substringByCodePointIndices(s, 0, length));
+        Assert.assertEquals("bc😀de", StringUtil.substringByCodePointIndices(s, 1, length - 1));
+        Assert.assertEquals(s.substring(1, s.length() - 1), StringUtil.substringByCodePointIndices(s, 1, length - 1));
+        Assert.assertEquals("bc😀de".substring(0, 0), StringUtil.substringByCodePointIndices(s, 0, 0));
+        Assert.assertEquals("a", StringUtil.substringByCodePointIndices(s, 0, 1));
+        Assert.assertEquals("c", StringUtil.substringByCodePointIndices(s, 2, 3));
+        Assert.assertEquals("😀", StringUtil.substringByCodePointIndices(s, 3, 4));
+        Assert.assertEquals("d", StringUtil.substringByCodePointIndices(s, 4, 5));
+        Assert.assertEquals("", StringUtil.substringByCodePointIndices(s, 0, 0));
+        Assert.assertEquals("".substring(0, 0), StringUtil.substringByCodePointIndices(s, 0, 0));
+    }
+
+    private String codePointsToString(int[] codePoints) {
+        return new String(codePoints, 0, codePoints.length);
+    }
+    @Test
+    public void testSubcodePointsByCodePointIndices() {
+        String s = "abc😀def";
+        final int length = Math.toIntExact(s.codePoints().count());
+        Assert.assertNotEquals(s.length(), length);
+        Assert.assertEquals(s, new String(StringUtil.subcodePointsByCodePointIndices(s, 0, length), 0, length));
+        Assert.assertEquals(s.substring(0, s.length()), codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 0, length)));
+        Assert.assertEquals("bc😀de", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 1, length - 1)));
+        Assert.assertEquals(s.substring(1, s.length() - 1), codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 1, length - 1)));
+        Assert.assertEquals("bc😀de".substring(0, 0), codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 0, 0)));
+        Assert.assertEquals("a", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 0, 1)));
+        Assert.assertEquals("c", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 2, 3)));
+        Assert.assertEquals("😀", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 3, 4)));
+        Assert.assertEquals("d", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 4, 5)));
+        Assert.assertEquals("e", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 5, 6)));
+        Assert.assertEquals("f", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 6, 7)));
+        Assert.assertEquals("", codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 0, 0)));
+        Assert.assertEquals("".substring(0, 0), codePointsToString(StringUtil.subcodePointsByCodePointIndices(s, 0, 0)));
     }
 
 }

--- a/wffweb/src/test/resources/com/webfirmframework/wffweb/json/testing_for_escape_char_sequence_json_sample1.json
+++ b/wffweb/src/test/resources/com/webfirmframework/wffweb/json/testing_for_escape_char_sequence_json_sample1.json
@@ -1,0 +1,87 @@
+{
+  "metadata": {
+    "version": "1.0.0",
+    "timestamp": "2025-02-21T12:34:56Z",
+    "source": "test_data",
+    "valid": true
+  },
+  "data": {
+    "id": 9876543210,
+    "name": "Complex JSON Test",
+    "description": "line1\nline2\nline3\n",
+    "isActive": false,
+    "nullField": null,
+    "emptyObject": {},
+    "emptyArray": [],
+    "specialCharacters": "\" \\ / \b \f \n \r \t",
+    "unicodeText": "𝒜𝒷𝒸𝒹 → ©®✓😊™",
+    "escapedUnicode": "    \uD83D\uDE80 \u2022 \u00A9 \u2122 ™ \n    ",
+    "largeNumbers": {
+      "positive": 1.7976931348623157e+308,
+      "negative": -1.7976931348623157e+308,
+      "tiny": 5e-324,
+      "integer": 9223372036854775807
+    },
+    "arrayTests": {
+      "emptyArray": [],
+      "simpleArray": [1, 2, 3, 4, 5],
+      "mixedArray": [true, false, null, "text", 42, {"key": "value"}],
+      "nestedArray": [[[[[["deep_value"]]]]]],
+      "longArray": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+    },
+    "deeplyNestedObject": {
+      "level1": {
+        "level2": {
+          "level3": {
+            "level4": {
+              "level5": {
+                "value": "Deep Value",
+                "more": {
+                  "nested": {
+                    "objects": {
+                      "finalLevel": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "circularReference": {
+      "self": { "reference": "This simulates circular reference indirectly" }
+    },
+    "complexObjectsArray": [
+      {
+        "id": 1,
+        "name": "Item 1",
+        "details": { "subDetail": "Value 1", "active": true }
+      },
+      {
+        "id": 2,
+        "name": "Item 2",
+        "details": { "subDetail": "Value 2", "active": false }
+      },
+      {
+        "id": 3,
+        "name": "Item 3",
+        "details": { "subDetail": "Value 3", "active": null }
+      }
+    ]
+  },
+  "booleanEdgeCases": {
+    "allTrue": [true, true, true, true],
+    "allFalse": [false, false, false, false],
+    "mixed": [true, false, null, true]
+  },
+  "numericEdgeCases": {
+    "zero": 0,
+    "negativeZero": -0,
+    "maxInt": 9007199254740991,
+    "minInt": -9007199254740991,
+    "floatingPoint": 3.141592653589793,
+    "scientificNotation": 6.022e23,
+    "smallNumber": 1e-10
+  }
+}


### PR DESCRIPTION
This release is mainly for the enhancements of JSON parser.

The existing `JsonParser` is more advanced now.

It focuses on the following:
  - In some cases, if the json data is large, the parsed json object (`JsonMapNode`) will not be used to get all values by keys. In most of the case we parse a large json text just to get few properties. There should be some mechanism to do a lazy parsing so that the json parsing process may be finished quickly. The JSON value part parsing process may be postponed, it can be done at the time of getting the value. The `JsonValue` value type implementation was incomplete for that purpose, this release contains needful enhancements for that.
 - Enhanced the basic parsing to more advanced parsing which will also parse unicode chars from json data to java chars if an optional argument `decodeUnicodeCharsSequence` is passed in string value getting methods. Now, the special/escape characters will be converted to JSON compatible string in the generated JSON string.
 - `convertTo` method is implemented in `JsonListNode` and `JsonMapNode`. It can convert `JsonListNode` and `JsonMapNode` to a user defined JSON object and JSON array classes respectively.
 - New `JsonConcurrentSkipListMap` is implemented.

#### Sample code to create `JsonValue` based parsing
```
JsonParser jsonParser = JsonParser.newBuilder()
                .jsonObjectType(JsonObjectType.JSON_MAP)
                .jsonArrayType(JsonArrayType.JSON_LIST)
                .jsonStringValueTypeForObject(JsonStringValueType.JSON_VALUE)
                .jsonStringValueTypeForArray(JsonStringValueType.JSON_VALUE)
                .jsonNumberValueTypeForObject(JsonNumberValueType.JSON_VALUE)
                .jsonNumberValueTypeForArray(JsonNumberValueType.JSON_VALUE)
                .jsonBooleanValueTypeForObject(JsonBooleanValueType.JSON_VALUE)
                .jsonBooleanValueTypeForArray(JsonBooleanValueType.JSON_VALUE)
                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE)
                .jsonNullValueTypeForObject(JsonNullValueType.JSON_VALUE).build();

JsonMap jsonMap = jsonParser.parseJsonObject(inputJsonObjectString) instanceof JsonMap jsonMapTmp ? jsonMapTmp : null;
```

#### `convertTo` method usage
```
class CustomJsonMap extends JsonLinkedMap {
}
class CustomList extends JsonList {
}
JsonLinkedMap jsonMap = new  JsonLinkedMap();
jsonMap.put("number", new JsonValue("14", JsonValueType.NUMBER));
jsonMap.put("string", new JsonValue("string value", JsonValueType.STRING));
jsonMap.put("bool", new JsonValue("true", JsonValueType.BOOLEAN));
jsonMap.put("fornull", new JsonValue());
JsonList jsonList1 = new JsonList();
jsonList1.add("one");
jsonList1.add("two");
jsonList1.add(3);
jsonList1.add(true);
jsonList1.add(null);
jsonMap.put("jsonList1", jsonList1);

CustomJsonMap convertedJsonMap = jsonMap.convertTo(
                CustomJsonMap::new, CustomJsonMap::put,
                CustomList::new, CustomList::add, true);


CustomJsonList convertedJsonList = jsonList1.convertTo(
                CustomJsonMap::new, CustomJsonMap::put,
                CustomJsonList::new, CustomJsonList::add, true);

```

### Other major changes
 - Code optimizations for performance improvement.